### PR TITLE
remove `test_case` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,6 @@ name = "belalang_compiler"
 version = "0.1.0"
 dependencies = [
  "belalang_vm",
- "test-case",
  "thiserror",
  "unicode-ident",
 ]
@@ -86,12 +85,6 @@ dependencies = [
  "belalang_macros",
  "thiserror",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -184,39 +177,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "test-case"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
-dependencies = [
- "test-case-macros",
-]
-
-[[package]]
-name = "test-case-core"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "test-case-macros"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "test-case-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,6 @@ name = "belalang_vm"
 version = "0.1.0"
 dependencies = [
  "belalang_macros",
- "test-case",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,3 @@ belalang_macros = { path = "./crates/belalang_macros" }
 belalang_vm = { path = "./crates/belalang_vm" }
 
 thiserror = "1.0.61"
-test-case = "3.3.1"

--- a/crates/belalang_compiler/Cargo.toml
+++ b/crates/belalang_compiler/Cargo.toml
@@ -27,6 +27,3 @@ debug = []
 belalang_vm.workspace = true
 thiserror.workspace = true
 unicode-ident = "1.0.18"
-
-[dev-dependencies]
-test-case.workspace = true

--- a/crates/belalang_compiler/tests/expressions.rs
+++ b/crates/belalang_compiler/tests/expressions.rs
@@ -8,11 +8,7 @@ use belalang_compiler::tokens::Token;
 use common::test_parse;
 use common::test_parse_to_string;
 
-use test_case::test_case;
-
-#[test_case("true;" => (Token::True, true); "_true")]
-#[test_case("false;" => (Token::False, false); "_false")]
-fn booleans(input: &str) -> (Token, bool) {
+fn test_booleans(input: &str, token: Token, value: bool) {
     let program = test_parse(input);
 
     assert_eq!(program.statements.len(), 1);
@@ -21,7 +17,18 @@ fn booleans(input: &str) -> (Token, bool) {
 
     let bool_expr = as_variant!(&expr.expression, ast::Expression::Boolean);
 
-    (bool_expr.token.clone(), bool_expr.value)
+    assert_eq!(bool_expr.token, token);
+    assert_eq!(bool_expr.value, value);
+}
+
+#[test]
+fn booleans_true() {
+    test_booleans("true;", Token::True, true);
+}
+
+#[test]
+fn booleans_false() {
+    test_booleans("false;", Token::False, false);
 }
 
 #[test]
@@ -146,22 +153,41 @@ fn function() {
     );
 }
 
-#[test_case("fn() {};" => Vec::<String>::new(); "no params")]
-#[test_case("fn(x) {};" => vec!["x"]; "one params")]
-#[test_case("fn(x, y) {};" => vec!["x", "y"]; "two params")]
-#[test_case("fn(x, y, z) {};" => vec!["x", "y", "z"]; "three params")]
-fn function_params(input: &str) -> Vec<String> {
+fn test_function_params(input: &str, output: Vec<&'static str>) {
     let program = test_parse(input);
 
     let stmt = as_variant!(&program.statements[0], ast::Statement::Expression);
 
     let function = as_variant!(&stmt.expression, ast::Expression::Function);
 
-    function
-        .params
-        .iter()
-        .map(|param| param.value.clone())
-        .collect::<Vec<String>>()
+    assert_eq!(
+        function
+            .params
+            .iter()
+            .map(|param| param.value.clone())
+            .collect::<Vec<_>>(),
+        output
+    )
+}
+
+#[test]
+fn function_params_no_params() {
+    test_function_params("fn() {};", Vec::new());
+}
+
+#[test]
+fn function_params_one_params() {
+    test_function_params("fn(x) {};", vec!["x"]);
+}
+
+#[test]
+fn function_params_two_params() {
+    test_function_params("fn(x, y) {};", vec!["x", "y"]);
+}
+
+#[test]
+fn function_params_three_params() {
+    test_function_params("fn(x, y, z) {};", vec!["x", "y", "z"]);
 }
 
 #[test]

--- a/crates/belalang_compiler/tests/lexer.rs
+++ b/crates/belalang_compiler/tests/lexer.rs
@@ -4,87 +4,107 @@ mod common;
 use belalang_compiler::tokens::Lexer;
 use belalang_compiler::tokens::Token;
 
-use test_case::test_case;
-
-#[test_case(
-    "=+(){}[],;!-/*5;5 < 10 > 5;:= >= <= += -= /= %= *= || &&" => vec![
-        Token::Assign,
-        Token::Add,
-        Token::LeftParen,
-        Token::RightParen,
-        Token::LeftBrace,
-        Token::RightBrace,
-        Token::LeftBracket,
-        Token::RightBracket,
-        Token::Comma,
-        Token::Semicolon,
-        Token::Not,
-        Token::Sub,
-        Token::Div,
-        Token::Mul,
-        Token::Int("5".into()),
-        Token::Semicolon,
-        Token::Int("5".into()),
-        Token::Lt,
-        Token::Int("10".into()),
-        Token::Gt,
-        Token::Int("5".into()),
-        Token::Semicolon,
-        Token::ColonAssign,
-        Token::Ge,
-        Token::Le,
-        Token::AddAssign,
-        Token::SubAssign,
-        Token::DivAssign,
-        Token::ModAssign,
-        Token::MulAssign,
-        Token::Or,
-        Token::And,
-    ]; "all"
-)]
-#[test_case(
-    r#""Hello, World"; "Test""# => vec![
-        Token::String("Hello, World".into()),
-        Token::Semicolon,
-        Token::String("Test".into()),
-    ]; "strings"
-)]
-#[test_case(
-    "123; 456; 789 + 1" => vec![
-        Token::Int("123".into()),
-        Token::Semicolon,
-        Token::Int("456".into()),
-        Token::Semicolon,
-        Token::Int("789".into()),
-        Token::Add,
-        Token::Int("1".into()),
-    ]; "integers"
-)]
-#[test_case(
-    "x; x + y" => vec![
-        Token::Ident("x".into()),
-        Token::Semicolon,
-        Token::Ident("x".into()),
-        Token::Add,
-        Token::Ident("y".into()),
-    ]; "identifiers"
-)]
-#[test_case(
-    r#""\n\r\t\"\x41""# => vec![
-        Token::String("\n\r\t\"A".into()),
-    ]; "escape_strings"
-)]
-fn tokens(input: &str) -> Vec<Token> {
+fn test_tokens(input: &str, expected: Vec<Token>) {
     let mut lexer = Lexer::new(input);
     let mut result = Vec::new();
-
     while let Ok(token) = lexer.next_token() {
         if let Token::EOF = token {
             break;
         }
-
         result.push(token);
     }
+    assert_eq!(result, expected);
+}
 
-    result
+#[test]
+fn tokens_all() {
+    test_tokens(
+        "=+(){}[],;!-/*5;5 < 10 > 5;:= >= <= += -= /= %= *= || &&",
+        vec![
+            Token::Assign,
+            Token::Add,
+            Token::LeftParen,
+            Token::RightParen,
+            Token::LeftBrace,
+            Token::RightBrace,
+            Token::LeftBracket,
+            Token::RightBracket,
+            Token::Comma,
+            Token::Semicolon,
+            Token::Not,
+            Token::Sub,
+            Token::Div,
+            Token::Mul,
+            Token::Int("5".into()),
+            Token::Semicolon,
+            Token::Int("5".into()),
+            Token::Lt,
+            Token::Int("10".into()),
+            Token::Gt,
+            Token::Int("5".into()),
+            Token::Semicolon,
+            Token::ColonAssign,
+            Token::Ge,
+            Token::Le,
+            Token::AddAssign,
+            Token::SubAssign,
+            Token::DivAssign,
+            Token::ModAssign,
+            Token::MulAssign,
+            Token::Or,
+            Token::And,
+        ],
+    );
+}
+
+#[test]
+fn tokens_strings() {
+    test_tokens(
+        r#""Hello, World"; "Test""#,
+        vec![
+            Token::String("Hello, World".into()),
+            Token::Semicolon,
+            Token::String("Test".into()),
+        ],
+    );
+}
+
+#[test]
+fn tokens_integers() {
+    test_tokens(
+        "123; 456; 789 + 1",
+        vec![
+            Token::Int("123".into()),
+            Token::Semicolon,
+            Token::Int("456".into()),
+            Token::Semicolon,
+            Token::Int("789".into()),
+            Token::Add,
+            Token::Int("1".into()),
+        ],
+    );
+}
+
+#[test]
+fn tokens_identifiers() {
+    test_tokens(
+        "x; x + y",
+        vec![
+            Token::Ident("x".into()),
+            Token::Semicolon,
+            Token::Ident("x".into()),
+            Token::Add,
+            Token::Ident("y".into()),
+        ],
+    );
+}
+
+#[test]
+fn tokens_escape_strings() {
+    test_tokens(
+        r#""\n\r\t\"\x41""#,
+        vec![
+            Token::String("\n\r\t\"A".into()),
+        ],
+    );
 }

--- a/crates/belalang_vm/Cargo.toml
+++ b/crates/belalang_vm/Cargo.toml
@@ -8,6 +8,3 @@ license = "Apache-2.0"
 [dependencies]
 belalang_macros.workspace = true
 thiserror.workspace = true
-
-[dev-dependencies]
-test-case.workspace = true

--- a/crates/belalang_vm/src/mem/heap.rs
+++ b/crates/belalang_vm/src/mem/heap.rs
@@ -107,16 +107,13 @@ impl Drop for Heap {
 #[cfg(test)]
 #[allow(clippy::bool_assert_comparison)]
 mod tests {
-    use test_case::test_case;
-
     use crate::objects::boolean::BelalangBoolean;
     use crate::objects::integer::BelalangInteger;
     use crate::objects::BelalangObject;
 
     use super::*;
 
-    #[test_case(vec![1, 2, 3]; "1")]
-    fn heap_alloc(data: Vec<i64>) {
+    fn test_heap_alloc(data: Vec<i64>) {
         let mut heap = Heap::default();
         let mut allocated_ptrs = Vec::new();
 
@@ -164,16 +161,18 @@ mod tests {
         assert!(current.is_none());
     }
 
+    #[test]
+    fn heap_alloc_simple() {
+        test_heap_alloc(vec![1, 2, 3]);
+    }
+
     #[derive(Debug)]
     enum Type {
         Integer(i64),
         Boolean(bool),
     }
 
-    #[test_case(vec![Type::Integer(1), Type::Boolean(true)]; "1")]
-    #[test_case(vec![Type::Integer(1), Type::Boolean(true), Type::Boolean(false)]; "2")]
-    #[test_case(vec![Type::Integer(1), Type::Boolean(true), Type::Integer(100)]; "3")]
-    fn heap_alloc_multiple_types(data: Vec<Type>) {
+    fn test_heap_alloc_multiple_types(data: Vec<Type>) {
         let mut heap = Heap::default();
         let mut allocated_ptrs = Vec::new();
 
@@ -244,8 +243,22 @@ mod tests {
         assert!(current.is_none());
     }
 
-    #[test_case(vec![1, 2, 3]; "1")]
-    fn heap_dealloc(data: Vec<i64>) {
+    #[test]
+    fn heap_alloc_multiple_types_case_1() {
+        test_heap_alloc_multiple_types(vec![Type::Integer(1), Type::Boolean(true)]);
+    }
+
+    #[test]
+    fn heap_alloc_multiple_types_case_2() {
+        test_heap_alloc_multiple_types(vec![Type::Integer(1), Type::Boolean(true), Type::Boolean(false)]);
+    }
+
+    #[test]
+    fn heap_alloc_multiple_types_case_3() {
+        test_heap_alloc_multiple_types(vec![Type::Integer(1), Type::Boolean(true), Type::Integer(100)]);
+    }
+
+    fn test_heap_dealloc(data: Vec<i64>) {
         let mut heap = Heap::default();
         let mut allocated_ptrs = Vec::new();
 
@@ -294,6 +307,11 @@ mod tests {
         }
 
         assert!(current.is_none());
+    }
+
+    #[test]
+    fn heap_dealloc_case_1() {
+        test_heap_dealloc(vec![1, 2, 3]);
     }
 
     #[test]

--- a/crates/belalang_vm/tests/objects.rs
+++ b/crates/belalang_vm/tests/objects.rs
@@ -11,14 +11,8 @@ use belalang_vm::objects::string::BelalangString;
 
 mod number {
     use super::*;
-    use test_case::test_case;
 
-    #[test_case(12, 5, opcode::ADD => 17; "addition")]
-    #[test_case(12, 5, opcode::SUB => 7; "subtraction")]
-    #[test_case(12, 5, opcode::MUL => 60; "multiplication")]
-    #[test_case(12, 5, opcode::DIV => 2; "division")]
-    #[test_case(12, 5, opcode::MOD => 2; "modulo")]
-    fn arithmetic_op(a: i64, b: i64, op: u8) -> i64 {
+    fn test_arithmetic_op(a: i64, b: i64, op: u8, c: i64) {
         let constants = vec![Constant::Integer(a), Constant::Integer(b)];
 
         let mut instructions = Vec::new();
@@ -44,14 +38,35 @@ mod number {
             panic!("TOS is not an Object!");
         };
 
-        unsafe { (object.as_ptr() as *mut BelalangInteger).read() }.value
+        assert_eq!(unsafe { (object.as_ptr() as *mut BelalangInteger).read() }.value, c);
     }
 
-    #[test_case(12, 12, opcode::EQUAL => true; "equal")]
-    #[test_case(12, 12, opcode::NOT_EQUAL => false; "not equal")]
-    #[test_case(12, 13, opcode::LESS_THAN => true; "less than")]
-    #[test_case(12, 12, opcode::LESS_THAN_EQUAL => true; "less than equal")]
-    fn comparison_op(a: i64, b: i64, op: u8) -> bool {
+    #[test]
+    fn arithmetic_op_addition() {
+        test_arithmetic_op(12, 5, opcode::ADD, 17);
+    }
+
+    #[test]
+    fn arithmetic_op_subtraction() {
+        test_arithmetic_op(12, 5, opcode::SUB, 7);
+    }
+
+    #[test]
+    fn arithmetic_op_multiplication() {
+        test_arithmetic_op(12, 5, opcode::MUL, 60);
+    }
+
+    #[test]
+    fn arithmetic_op_division() {
+        test_arithmetic_op(12, 5, opcode::DIV, 2);
+    }
+
+    #[test]
+    fn arithmetic_op_modulo() {
+        test_arithmetic_op(12, 5, opcode::MOD, 2);
+    }
+
+    fn test_comparison_op(a: i64, b: i64, op: u8, c: bool) {
         let constants = vec![Constant::Integer(a), Constant::Integer(b)];
 
         let mut instructions = Vec::new();
@@ -77,15 +92,30 @@ mod number {
             panic!("TOS is not an Object!");
         };
 
-        unsafe { (object.as_ptr() as *mut BelalangBoolean).read() }.value
+        assert_eq!(unsafe { (object.as_ptr() as *mut BelalangBoolean).read() }.value, c);
     }
 
-    #[test_case(12, 1, opcode::BIT_AND => 0; "bit and")]
-    #[test_case(12, 1, opcode::BIT_OR => 13; "bit or")]
-    #[test_case(12, 1, opcode::BIT_XOR => 13; "bit xor")]
-    #[test_case(12, 1, opcode::BIT_SL => 24; "bit sl")]
-    #[test_case(12, 1, opcode::BIT_SR => 6; "bit sr")]
-    fn bitwise_op(a: i64, b: i64, op: u8) -> i64 {
+    #[test]
+    fn comparison_op_equal() {
+        test_comparison_op(12, 12, opcode::EQUAL, true);
+    }
+
+    #[test]
+    fn comparison_op_not_equal() {
+        test_comparison_op(12, 12, opcode::NOT_EQUAL, false);
+    }
+
+    #[test]
+    fn comparison_op_less_than() {
+        test_comparison_op(12, 13, opcode::LESS_THAN, true);
+    }
+
+    #[test]
+    fn comparison_op_less_than_equal() {
+        test_comparison_op(12, 12, opcode::LESS_THAN_EQUAL, true);
+    }
+
+    fn test_bitwise_op(a: i64, b: i64, op: u8, c: i64) {
         let constants = vec![Constant::Integer(a), Constant::Integer(b)];
 
         let mut instructions = Vec::new();
@@ -111,7 +141,32 @@ mod number {
             panic!("TOS is not an Object!");
         };
 
-        unsafe { (object.as_ptr() as *mut BelalangInteger).read() }.value
+        assert_eq!(unsafe { (object.as_ptr() as *mut BelalangInteger).read() }.value, c)
+    }
+
+    #[test]
+    fn bitwise_op_bit_and() {
+        test_bitwise_op(12, 1, opcode::BIT_AND, 0);
+    }
+
+    #[test]
+    fn bitwise_op_bit_or() {
+        test_bitwise_op(12, 1, opcode::BIT_OR, 13);
+    }
+
+    #[test]
+    fn bitwise_op_bit_xor() {
+        test_bitwise_op(12, 1, opcode::BIT_OR, 13);
+    }
+
+    #[test]
+    fn bitwise_op_bit_sl() {
+        test_bitwise_op(12, 1, opcode::BIT_SL, 24);
+    }
+
+    #[test]
+    fn bitwise_op_bit_sr() {
+        test_bitwise_op(12, 1, opcode::BIT_SR, 6);
     }
 
     #[test]
@@ -148,11 +203,8 @@ mod number {
 
 mod boolean {
     use super::*;
-    use test_case::test_case;
 
-    #[test_case(true, true, opcode::EQUAL => true; "equal")]
-    #[test_case(true, false, opcode::NOT_EQUAL => true; "not equal")]
-    fn comparison_op(a: bool, b: bool, op: u8) -> bool {
+    fn test_comparison_op(a: bool, b: bool, op: u8, c: bool) {
         let constants = vec![Constant::Boolean(a), Constant::Boolean(b)];
 
         let mut instructions = Vec::new();
@@ -178,12 +230,20 @@ mod boolean {
             panic!("TOS is not an Object!");
         };
 
-        unsafe { (object.as_ptr() as *mut BelalangBoolean).read() }.value
+        assert_eq!(unsafe { (object.as_ptr() as *mut BelalangBoolean).read() }.value, c);
     }
 
-    #[test_case(true, false, opcode::AND => false; "and")]
-    #[test_case(true, false, opcode::OR => true; "or")]
-    fn logical_op(a: bool, b: bool, op: u8) -> bool {
+    #[test]
+    fn comparison_op_equal() {
+        test_comparison_op(true, true, opcode::EQUAL, true);
+    }
+
+    #[test]
+    fn comparison_op_not_equal() {
+        test_comparison_op(true, false, opcode::NOT_EQUAL, true);
+    }
+
+    fn test_logical_op(a: bool, b: bool, op: u8, c: bool) {
         let constants = vec![Constant::Boolean(a), Constant::Boolean(b)];
 
         let mut instructions = Vec::new();
@@ -209,7 +269,17 @@ mod boolean {
             panic!("TOS is not an Object!");
         };
 
-        unsafe { (object.as_ptr() as *mut BelalangBoolean).read() }.value
+        assert_eq!(unsafe { (object.as_ptr() as *mut BelalangBoolean).read() }.value, c);
+    }
+
+    #[test]
+    fn logical_op_and() {
+        test_logical_op(true, false, opcode::AND, false);
+    }
+
+    #[test]
+    fn logical_op_or() {
+        test_logical_op(true, false, opcode::OR, true);
     }
 
     #[test]
@@ -246,7 +316,6 @@ mod boolean {
 
 mod string {
     use super::*;
-    use test_case::test_case;
 
     #[test]
     fn init() {
@@ -277,11 +346,7 @@ mod string {
         assert_eq!(format!("{string}"), "Hello");
     }
 
-    #[test_case("Hello", -1 => (String::from(""), 0); "mul neg 1")]
-    #[test_case("Hello", 0 => (String::from(""), 0); "mul 0")]
-    #[test_case("Hello", 1 => (String::from("Hello"), 5); "mul 1")]
-    #[test_case("Hello", 3 => (String::from("HelloHelloHello"), 15); "mul 3")]
-    fn arithmetic_op_mul(string: &'static str, num: i64) -> (String, usize) {
+    fn test_arithmetic_op_mul(string: &'static str, num: i64, expected_string: &str, expected_len: usize) {
         let constants = vec![Constant::String(string), Constant::Integer(num)];
 
         let mut instructions = Vec::new();
@@ -308,12 +373,32 @@ mod string {
         };
 
         let string = unsafe { (object.as_ptr() as *mut BelalangString).read() };
-
-        (format!("{string}"), string.len)
+        
+        assert_eq!(format!("{string}"), expected_string);
+        assert_eq!(string.len, expected_len);
     }
 
-    #[test_case("Hello", ", World!" => String::from("Hello, World!"); "hello world")]
-    fn arithmetic_op_add(string_1: &'static str, string_2: &'static str) -> String {
+    #[test]
+    fn arithmetic_op_mul_neg_1() {
+        test_arithmetic_op_mul("Hello", -1, "", 0);
+    }
+
+    #[test]
+    fn arithmetic_op_mul_0() {
+        test_arithmetic_op_mul("Hello", 0, "", 0);
+    }
+
+    #[test]
+    fn arithmetic_op_mul_1() {
+        test_arithmetic_op_mul("Hello", 1, "Hello", 5);
+    }
+
+    #[test]
+    fn arithmetic_op_mul_3() {
+        test_arithmetic_op_mul("Hello", 3, "HelloHelloHello", 15);
+    }
+
+    fn test_arithmetic_op_add(string_1: &'static str, string_2: &'static str, expected: &str) {
         let constants = vec![Constant::String(string_1), Constant::String(string_2)];
 
         let mut instructions = Vec::new();
@@ -340,8 +425,13 @@ mod string {
         };
 
         let string = unsafe { (object.as_ptr() as *mut BelalangString).read() };
+        
+        assert_eq!(format!("{string}"), expected);
+    }
 
-        format!("{string}")
+    #[test]
+    fn arithmetic_op_add_hello_world() {
+        test_arithmetic_op_add("Hello", ", World!", "Hello, World!");
     }
 }
 


### PR DESCRIPTION
This PR removes the `test_case` dev dependency from test files.

While `test_case` offers a concise way to write parameterized tests, I've decided to prioritize verbosity for better readability and debugging experience. One key issue I had with `test_case` is that the error line numbers reported by `cargo test` can be misleading due to macro expansion. This made it harder to quickly identify and fix failing tests.

