### PR TITLE
[bir] first implementation of BIRToLLVM pass

### DIFF
--- a/bir/BUILD.bazel
+++ b/bir/BUILD.bazel
@@ -70,6 +70,7 @@ cc_library(
         "lib/IR/BIROps.cpp",
         "lib/Transforms/Constantize.cpp",
         "lib/Transforms/Runtimize.cpp",
+        "lib/Transforms/BIRToLLVM.cpp",
     ],
     deps = [
         ":bir-include",

--- a/bir/BUILD.bazel
+++ b/bir/BUILD.bazel
@@ -83,6 +83,7 @@ cc_library(
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:LLVMDialect",
         "@llvm-project//mlir:TransformUtils",
     ],
     linkopts = select({

--- a/bir/include/belalang/BIR/IR/BIROps.td
+++ b/bir/include/belalang/BIR/IR/BIROps.td
@@ -153,11 +153,11 @@ def FuncOp : BIR_Op<"func", [FunctionOpInterface, CallableOpInterface,
     // FunctionOpInterface
     // -------------------------------------------------------------------------
 
-    Region *getCallableRegion() { return &getBody(); }
+    ::mlir::Region *getCallableRegion() { return &getBody(); }
 
-    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+    ArrayRef<::mlir::Type> getArgumentTypes() { return getFunctionType().getInputs(); }
 
-    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+    ArrayRef<::mlir::Type> getResultTypes() { return getFunctionType().getResults(); }
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/bir/include/belalang/BIR/Passes.h
+++ b/bir/include/belalang/BIR/Passes.h
@@ -2,6 +2,7 @@
 #define BELALANG_PASSES_H_
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
 
 namespace belalang {

--- a/bir/include/belalang/BIR/Passes.h
+++ b/bir/include/belalang/BIR/Passes.h
@@ -4,6 +4,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 namespace belalang {
 namespace bir {
@@ -16,7 +17,8 @@ namespace bir {
 
 void populateBelalangConstantsPatterns(mlir::RewritePatternSet &patterns);
 void populateBelalangRuntimizePatterns(mlir::RewritePatternSet &patterns);
-void populateBelalangBIRToLLVMPatterns(mlir::RewritePatternSet &patterns);
+void populateBelalangBIRToLLVMPatterns(mlir::RewritePatternSet &patterns,
+                                       mlir::TypeConverter typeConverter);
 
 } // namespace bir
 } // namespace belalang

--- a/bir/include/belalang/BIR/Passes.h
+++ b/bir/include/belalang/BIR/Passes.h
@@ -18,7 +18,7 @@ namespace bir {
 void populateBelalangConstantsPatterns(mlir::RewritePatternSet &patterns);
 void populateBelalangRuntimizePatterns(mlir::RewritePatternSet &patterns);
 void populateBelalangBIRToLLVMPatterns(mlir::RewritePatternSet &patterns,
-                                       mlir::TypeConverter typeConverter);
+                                       mlir::TypeConverter &typeConverter);
 
 } // namespace bir
 } // namespace belalang

--- a/bir/include/belalang/BIR/Passes.h
+++ b/bir/include/belalang/BIR/Passes.h
@@ -16,6 +16,7 @@ namespace bir {
 
 void populateBelalangConstantsPatterns(mlir::RewritePatternSet &patterns);
 void populateBelalangRuntimizePatterns(mlir::RewritePatternSet &patterns);
+void populateBelalangBIRToLLVMPatterns(mlir::RewritePatternSet &patterns);
 
 } // namespace bir
 } // namespace belalang

--- a/bir/include/belalang/BIR/Passes.td
+++ b/bir/include/belalang/BIR/Passes.td
@@ -15,4 +15,10 @@ def BelalangRuntimizePass : Pass<"runtimize"> {
                            "::mlir::func::FuncDialect"];
 }
 
+def BelalangBIRToLLVMPass : Pass<"bir-to-llvm"> {
+  let summary = "lower bir instructions to LLVM";
+  let dependentDialects = ["::belalang::bir::BIRDialect",
+                           "::mlir::LLVM::LLVMDialect"];
+}
+
 #endif // BELALANG_PASSES_TD_

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -22,6 +22,14 @@ struct ConstantOpLowering final : public OpConversionPattern<bir::ConstantOp> {
   }
 };
 
+struct BIRToLLVMTypeConverter : public mlir::TypeConverter {
+  BIRToLLVMTypeConverter() {
+    addConversion([](bir::IntType ty) {
+      return mlir::IntegerType::get(ty.getContext(), 32);
+    });
+  }
+};
+
 } // namespace
 
 void belalang::bir::populateBelalangBIRToLLVMPatterns(
@@ -39,11 +47,7 @@ struct BelalangBIRToLLVMPass
       BelalangBIRToLLVMPass>::BelalangBIRToLLVMPassBase;
 
   void runOnOperation() override {
-    mlir::TypeConverter typeConverter;
-
-    typeConverter.addConversion([](bir::IntType ty) {
-      return mlir::IntegerType::get(ty.getContext(), 32);
-    });
+    BIRToLLVMTypeConverter typeConverter;
 
     mlir::ConversionTarget target(getContext());
     target.addLegalDialect<mlir::LLVM::LLVMDialect>();

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -18,7 +18,21 @@ struct ConstantOpLowering final : public OpConversionPattern<bir::ConstantOp> {
   LogicalResult
   matchAndRewrite(bir::ConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    return failure();
+    auto type = getTypeConverter()->convertType(op.getType());
+    if (!type)
+      return failure();
+
+    Attribute value = op.getValue();
+    if (auto intAttr = llvm::dyn_cast<IntegerAttr>(value)) {
+      value = rewriter.getIntegerAttr(type, intAttr.getValue());
+    } else if (auto floatAttr = llvm::dyn_cast<FloatAttr>(value)) {
+      value = rewriter.getFloatAttr(type, floatAttr.getValue());
+    } else {
+      return failure();
+    }
+
+    rewriter.replaceOpWithNewOp<LLVM::ConstantOp>(op, type, value);
+    return success();
   }
 };
 
@@ -27,13 +41,16 @@ struct BIRToLLVMTypeConverter : public mlir::TypeConverter {
     addConversion([](bir::IntType ty) {
       return mlir::IntegerType::get(ty.getContext(), 32);
     });
+    addConversion([](bir::FloatType ty) {
+      return mlir::Float32Type::get(ty.getContext());
+    });
   }
 };
 
 } // namespace
 
 void belalang::bir::populateBelalangBIRToLLVMPatterns(
-    mlir::RewritePatternSet &patterns, mlir::TypeConverter typeConverter) {
+    mlir::RewritePatternSet &patterns, mlir::TypeConverter &typeConverter) {
   patterns.add<ConstantOpLowering>(typeConverter, patterns.getContext());
 }
 
@@ -52,6 +69,9 @@ struct BelalangBIRToLLVMPass
     mlir::ConversionTarget target(getContext());
     target.addLegalDialect<mlir::LLVM::LLVMDialect>();
     target.addIllegalDialect<bir::BIRDialect>();
+
+    // TODO: make this full by making all bir ops illegal
+    target.addLegalOp<bir::FuncOp, bir::ReturnOp>();
 
     mlir::RewritePatternSet patterns(&getContext());
     belalang::bir::populateBelalangBIRToLLVMPatterns(patterns, typeConverter);

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -13,8 +13,10 @@ using namespace mlir;
 using namespace belalang;
 
 struct ConstantOpLowering final : public OpConversionPattern<bir::ConstantOp> {
+  using OpConversionPattern<bir::ConstantOp>::OpConversionPattern;
+
   LogicalResult
-  matchAndRewrite(bir::ConstantOp *op, ArrayRef<Value> operands,
+  matchAndRewrite(bir::ConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     return failure();
   }
@@ -23,8 +25,8 @@ struct ConstantOpLowering final : public OpConversionPattern<bir::ConstantOp> {
 } // namespace
 
 void belalang::bir::populateBelalangBIRToLLVMPatterns(
-    mlir::RewritePatternSet &patterns) {
-  patterns.add<ConstantOpLowering>();
+    mlir::RewritePatternSet &patterns, mlir::TypeConverter typeConverter) {
+  patterns.add<ConstantOpLowering>(typeConverter, patterns.getContext());
 }
 
 // -----------------------------------------------------------------------------
@@ -37,12 +39,18 @@ struct BelalangBIRToLLVMPass
       BelalangBIRToLLVMPass>::BelalangBIRToLLVMPassBase;
 
   void runOnOperation() override {
+    mlir::TypeConverter typeConverter;
+
+    typeConverter.addConversion([](bir::IntType ty) {
+      return mlir::IntegerType::get(ty.getContext(), 32);
+    });
+
     mlir::ConversionTarget target(getContext());
     target.addLegalDialect<mlir::LLVM::LLVMDialect>();
     target.addIllegalDialect<bir::BIRDialect>();
 
     mlir::RewritePatternSet patterns(&getContext());
-    belalang::bir::populateBelalangBIRToLLVMPatterns(patterns);
+    belalang::bir::populateBelalangBIRToLLVMPatterns(patterns, typeConverter);
 
     if (mlir::failed(mlir::applyPartialConversion(getOperation(), target,
                                                   std::move(patterns)))) {
@@ -50,3 +58,7 @@ struct BelalangBIRToLLVMPass
     }
   }
 };
+
+std::unique_ptr<mlir::Pass> belalang::bir::createBelalangBIRToLLVMPass() {
+  return std::make_unique<BelalangBIRToLLVMPass>();
+}

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -1,0 +1,52 @@
+#include "belalang/BIR/IR/BIR.h"
+#include "belalang/BIR/Passes.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_BELALANGBIRTOLLVMPASS
+#include "belalang/BIR/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+
+using namespace mlir;
+using namespace belalang;
+
+struct ConstantOpLowering final : public OpConversionPattern<bir::ConstantOp> {
+  LogicalResult
+  matchAndRewrite(bir::ConstantOp *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    return failure();
+  }
+};
+
+} // namespace
+
+void belalang::bir::populateBelalangBIRToLLVMPatterns(
+    mlir::RewritePatternSet &patterns) {
+  patterns.add<ConstantOpLowering>();
+}
+
+// -----------------------------------------------------------------------------
+// The Pass
+// -----------------------------------------------------------------------------
+
+struct BelalangBIRToLLVMPass
+    : public impl::BelalangBIRToLLVMPassBase<BelalangBIRToLLVMPass> {
+  using impl::BelalangBIRToLLVMPassBase<
+      BelalangBIRToLLVMPass>::BelalangBIRToLLVMPassBase;
+
+  void runOnOperation() override {
+    mlir::ConversionTarget target(getContext());
+    target.addLegalDialect<mlir::LLVM::LLVMDialect>();
+    target.addIllegalDialect<bir::BIRDialect>();
+
+    mlir::RewritePatternSet patterns(&getContext());
+    belalang::bir::populateBelalangBIRToLLVMPatterns(patterns);
+
+    if (mlir::failed(mlir::applyPartialConversion(getOperation(), target,
+                                                  std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};

--- a/tests/BIR/Transforms/llvm.mlir
+++ b/tests/BIR/Transforms/llvm.mlir
@@ -1,4 +1,42 @@
+// RUN: %bir-opt --split-input-file --bir-to-llvm %s | %FileCheck %s
+
+// CHECK:      module {
+// CHECK-NEXT:   bir.func @main() {
+// CHECK-NEXT:     %[[C0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:     bir.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
 bir.func @main() {
   %0 = bir.constant 0 : !bir.int
   bir.return
 }
+
+// -----
+
+// CHECK:      module {
+// CHECK-NEXT:   bir.func @main() {
+// CHECK-NEXT:     %[[C0:.*]] = llvm.mlir.constant(0.000000e+00 : f32) : f32
+// CHECK-NEXT:     bir.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+bir.func @main() {
+  %0 = bir.constant 0.00 : !bir.float
+  bir.return
+}
+
+// -----
+
+// CHECK:      module {
+// CHECK-NEXT:   bir.func @main() {
+// CHECK-NEXT:     %[[C0:.*]] = llvm.mlir.constant(1.230000e+00 : f32) : f32
+// CHECK-NEXT:     bir.return
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+bir.func @main() {
+  %0 = bir.constant 1.23 : !bir.float
+  bir.return
+}
+

--- a/tests/BIR/Transforms/llvm.mlir
+++ b/tests/BIR/Transforms/llvm.mlir
@@ -1,0 +1,4 @@
+bir.func @main() {
+  %0 = bir.constant 0 : !bir.int
+  bir.return
+}


### PR DESCRIPTION
Currently, the BIRToLLVM pass only lowers `bir.constant` op to `llvm.mlir.constant`.