### PR TITLE
[chore] Add Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,19 @@
+alias b := build
+alias t := test
+alias opt := bir-opt
+alias bel := belalang
+
+default:
+	@just --list
+
+build:
+	bazelisk build //...
+
+test:
+	bazelisk test //...
+
+bir-opt *args:
+	./bazel-bin/bir/bir-opt {{args}}
+
+belalang *args:
+	./bazel-bin/cli/belalang {{args}}

--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,7 @@
    pkgs.zlib
    pkgs.python313
    pkgs.clang-tools
+   pkgs.just
  ];
  profile = ''
    export BRT_DIR="${toString ./.}/bazel-bin/brt"


### PR DESCRIPTION
I find myself running these commands quite often:

- `bazelisk build //...`
- `bazelisk test //...`
- `./bazel-bin/cli/belalang`
- `./bazel-bin/bir/bir-opt`

To simplify, this change adds a Justfile to help shorten these commands.