### PR TITLE
[lexer] Use string slicing

### DIFF
--- a/lexer/src/lexer.rs
+++ b/lexer/src/lexer.rs
@@ -534,20 +534,20 @@ impl<'sess> Lexer<'sess> {
     }
 
     fn read_identifier(&mut self) -> Result<Token, LexerError> {
+        let start_offset = self.current_offset;
         match self.current {
             Some(c) if is_xid_start(c) => {
-                let mut identifier = String::from(c);
                 self.advance();
 
                 while let Some(c) = self.current {
                     if is_xid_continue(c) {
-                        identifier.push(c);
                         self.advance();
                     } else {
                         break;
                     }
                 }
 
+                let identifier = &self.session.source_text[start_offset..self.current_offset];
                 let sym = self.session.intern_string(&identifier);
                 let kind = match sym {
                     syms::FN => TokenKind::Function,


### PR DESCRIPTION
Before the addition of the byte offset, the identifier string is generated via push calls. Now that lexer performs by adding to byte offset, the identifier string can be found by slicing the source string.