### PR TITLE
[ast] Remove display implementations from nodes

### DIFF
--- a/ast/src/expressions.rs
+++ b/ast/src/expressions.rs
@@ -24,12 +24,6 @@ pub struct BooleanExpression {
     pub value: bool,
 }
 
-impl std::fmt::Display for BooleanExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.value)
-    }
-}
-
 /// Represents an integer literal expression.
 ///
 /// # Examples
@@ -40,12 +34,6 @@ impl std::fmt::Display for BooleanExpression {
 #[derive(Debug, Clone)]
 pub struct IntegerLiteral {
     pub value: i64,
-}
-
-impl std::fmt::Display for IntegerLiteral {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.value)
-    }
 }
 
 /// Represents an float literal expression.
@@ -60,12 +48,6 @@ pub struct FloatLiteral {
     pub value: f64,
 }
 
-impl std::fmt::Display for FloatLiteral {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.value)
-    }
-}
-
 /// Represents an string literal expression.
 ///
 /// # Examples
@@ -78,12 +60,6 @@ pub struct StringLiteral {
     pub value: Symbol,
 }
 
-impl std::fmt::Display for StringLiteral {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.value)
-    }
-}
-
 /// Represents an null literal expression.
 ///
 /// # Examples
@@ -93,12 +69,6 @@ impl std::fmt::Display for StringLiteral {
 /// ```
 #[derive(Debug, Clone)]
 pub struct NullLiteral {}
-
-impl std::fmt::Display for NullLiteral {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "null")
-    }
-}
 
 /// Represents an array literal expression.
 ///
@@ -110,19 +80,6 @@ impl std::fmt::Display for NullLiteral {
 #[derive(Debug, Clone)]
 pub struct ArrayLiteral {
     pub elements: Vec<Expression>,
-}
-
-impl std::fmt::Display for ArrayLiteral {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let elements = self
-            .elements
-            .iter()
-            .map(|arg| arg.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        write!(f, "[{elements}]")
-    }
 }
 
 /// Represents a variable declaration expression.
@@ -140,12 +97,6 @@ pub struct VarDeclExpression {
     pub explicit_ty: Option<Type>,
 }
 
-impl std::fmt::Display for VarDeclExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {:?} {:?}", self.name, self.explicit_ty, self.value)
-    }
-}
-
 /// Represents an variable assignment literal expression.
 ///
 /// # Examples
@@ -158,12 +109,6 @@ pub struct VarExpression {
     pub kind: AssignmentKind,
     pub name: Identifier,
     pub value: Box<Expression>,
-}
-
-impl std::fmt::Display for VarExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {} {};", self.name, self.kind, self.value)
-    }
 }
 
 /// Represents a function call expression.
@@ -179,19 +124,6 @@ pub struct CallExpression {
     pub args: Vec<Expression>,
 }
 
-impl std::fmt::Display for CallExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let args = self
-            .args
-            .iter()
-            .map(|arg| arg.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        write!(f, "{}({})", self.function, args)
-    }
-}
-
 /// Represents an indexing expression.
 ///
 /// # Examples
@@ -203,12 +135,6 @@ impl std::fmt::Display for CallExpression {
 pub struct IndexExpression {
     pub left: Box<Expression>,
     pub index: Box<Expression>,
-}
-
-impl std::fmt::Display for IndexExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({}[{}])", self.left, self.index)
-    }
 }
 
 /// Represents a function expression.
@@ -224,19 +150,6 @@ pub struct FunctionLiteral {
     pub body: BlockExpression,
 }
 
-impl std::fmt::Display for FunctionLiteral {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params = self
-            .params
-            .iter()
-            .map(|param| param.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        write!(f, "fn({}) {}", params, self.body)
-    }
-}
-
 /// Represents an identifier expression.
 ///
 /// # Examples
@@ -247,12 +160,6 @@ impl std::fmt::Display for FunctionLiteral {
 #[derive(Debug, Clone)]
 pub struct Identifier {
     pub value: Symbol,
-}
-
-impl std::fmt::Display for Identifier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.value)
-    }
 }
 
 /// Represents an if expression.
@@ -269,21 +176,6 @@ pub struct IfExpression {
     pub alternative: Option<Box<Expression>>,
 }
 
-impl std::fmt::Display for IfExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "if ({}) {} else {}",
-            self.condition,
-            self.consequence,
-            match &self.alternative {
-                Some(alt) => alt.to_string(),
-                None => "{}".into(),
-            }
-        )
-    }
-}
-
 /// Represents an infix expression.
 ///
 /// # Examples
@@ -296,12 +188,6 @@ pub struct InfixExpression {
     pub left: Box<Expression>,
     pub operator: InfixKind,
     pub right: Box<Expression>,
-}
-
-impl std::fmt::Display for InfixExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({} {} {})", self.left, self.operator, self.right)
-    }
 }
 
 /// Represents an prefix expression.
@@ -317,12 +203,6 @@ pub struct PrefixExpression {
     pub right: Box<Expression>,
 }
 
-impl std::fmt::Display for PrefixExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({}{})", self.operator, self.right)
-    }
-}
-
 /// Represents an code block expression.
 ///
 /// This is used in while statements, if expressions, and etc that needs a code
@@ -336,19 +216,6 @@ impl std::fmt::Display for PrefixExpression {
 #[derive(Debug, Clone)]
 pub struct BlockExpression {
     pub statements: Vec<Statement>,
-}
-
-impl std::fmt::Display for BlockExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let statements = self
-            .statements
-            .iter()
-            .map(|statement| statement.to_string())
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        write!(f, "{{ {statements} }}")
-    }
 }
 
 /// Represents all expressions supported by The Belalang Compiler.
@@ -370,27 +237,4 @@ pub enum Expression {
     Infix(InfixExpression),
     Prefix(PrefixExpression),
     Block(BlockExpression),
-}
-
-impl std::fmt::Display for Expression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&match self {
-            Expression::Boolean(v) => v.to_string(),
-            Expression::Integer(v) => v.to_string(),
-            Expression::Float(v) => v.to_string(),
-            Expression::String(v) => v.to_string(),
-            Expression::Null(v) => v.to_string(),
-            Expression::Array(v) => v.to_string(),
-            Expression::Var(v) => v.to_string(),
-            Expression::VarDecl(v) => v.to_string(),
-            Expression::Call(v) => v.to_string(),
-            Expression::Index(v) => v.to_string(),
-            Expression::Function(v) => v.to_string(),
-            Expression::Identifier(v) => v.to_string(),
-            Expression::If(v) => v.to_string(),
-            Expression::Infix(v) => v.to_string(),
-            Expression::Prefix(v) => v.to_string(),
-            Expression::Block(v) => v.to_string(),
-        })
-    }
 }

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -35,7 +35,7 @@ pub enum ParserError {
     #[error("unexpected token: {0}")]
     UnexpectedToken(TokenKind),
 
-    #[error("invalid lhs: {0}")]
+    #[error("invalid lhs: {0:?}")]
     InvalidLHS(Expression),
 
     #[error("error parsing integer: could not parse {0} as integer")]

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -35,8 +35,8 @@ pub enum ParserError {
     #[error("unexpected token: {0}")]
     UnexpectedToken(TokenKind),
 
-    #[error("invalid lhs: {0:?}")]
-    InvalidLHS(Expression),
+    #[error("invalid lhs")]
+    InvalidLHS,
 
     #[error("error parsing integer: could not parse {0} as integer")]
     ParsingInteger(String),

--- a/ast/src/parser.rs
+++ b/ast/src/parser.rs
@@ -586,11 +586,11 @@ impl<'sess> Parser<'sess> {
         ParserError::UnknownPrefixOperator(self.curr_token.kind)
     }
 
-    fn error_invalid_lhs(&self, left: &Expression) -> ParserError {
+    fn error_invalid_lhs(&self, _left: &Expression) -> ParserError {
         // TODO: change this with expression span
         let label = Label::primary(self.curr_token.span, "invalid lhs");
         self.session.emit(Diagnostic::error("invalid lhs").with_label(label));
-        ParserError::InvalidLHS(left.clone())
+        ParserError::InvalidLHS
     }
 
     fn error_parsing_integer(&self, v: &str) -> ParserError {

--- a/ast/src/program.rs
+++ b/ast/src/program.rs
@@ -10,15 +10,3 @@ impl Program {
         self.statements.push(stmt);
     }
 }
-
-impl std::fmt::Display for Program {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut result = String::new();
-
-        for stmt in &self.statements {
-            result.push_str(&stmt.to_string());
-        }
-
-        f.write_str(&result)
-    }
-}

--- a/ast/src/statements.rs
+++ b/ast/src/statements.rs
@@ -8,21 +8,9 @@ pub struct ExpressionStatement {
     pub expression: Expression,
 }
 
-impl std::fmt::Display for ExpressionStatement {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{};", &self.expression)
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct ReturnStatement {
     pub return_value: Expression,
-}
-
-impl std::fmt::Display for ReturnStatement {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "return {};", self.return_value)
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -31,27 +19,9 @@ pub struct WhileStatement {
     pub block: BlockExpression,
 }
 
-impl std::fmt::Display for WhileStatement {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "while ({}) {}", self.condition, self.block)
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum Statement {
     Expression(ExpressionStatement),
     Return(ReturnStatement),
     While(WhileStatement),
-}
-
-impl std::fmt::Display for Statement {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let value = match self {
-            Statement::Expression(v) => v.to_string(),
-            Statement::Return(v) => v.to_string(),
-            Statement::While(v) => v.to_string(),
-        };
-
-        f.write_str(&value)
-    }
 }


### PR DESCRIPTION
We don't use those Displays. The AST representation requires more knowledge, e.g. session for symbol lookups. We also have plans in #212 to move to an arena allocation representation and having these unused Displays will complicate the move.