### PR TITLE
[cli][bbuild] Add temporary directories as output directory

### DIFF
--- a/bbuild/src/lib.rs
+++ b/bbuild/src/lib.rs
@@ -28,6 +28,7 @@ use ty::TypeInferer;
 pub struct BuildContext {
     pub use_color: bool,
     pub emit: EmitTarget,
+    pub out_dir: PathBuf,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -63,8 +64,8 @@ impl BBuild {
         let cc = env::var("CC").unwrap_or("cc".to_string());
         let brt_dir = env::var("BRT_DIR").unwrap_or_else(|_| "/usr/local/lib".to_string());
 
-        let out_obj = PathBuf::from("belalang_out.o");
-        let out_exe = PathBuf::from("belalang_out");
+        let out_obj = bctx.out_dir.join("belalang_out.o");
+        let out_exe = bctx.out_dir.join("belalang_out");
 
         let mut source_text = String::new();
         io::stdin()
@@ -88,8 +89,15 @@ impl BBuild {
         let cc = env::var("CC").unwrap_or("cc".to_string());
         let brt_dir = env::var("BRT_DIR").unwrap_or_else(|_| "/usr/local/lib".to_string());
 
-        let out_obj = source_path.with_added_extension("o");
-        let out_exe = source_path.with_extension("");
+        let mut out_obj = source_path.with_added_extension("o");
+        let mut out_exe = source_path.with_extension("");
+
+        if let Some(file_name) = out_obj.file_name() {
+            out_obj = bctx.out_dir.join(file_name);
+        }
+        if let Some(file_name) = out_exe.file_name() {
+            out_exe = bctx.out_dir.join(file_name);
+        }
 
         let session = Session::for_file(source_path.to_path_buf())?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@ use std::{
     str::FromStr,
 };
 
+use anyhow::Context;
 use bbuild::{
     BuildContext,
     EmitTarget,
@@ -157,7 +158,11 @@ fn main() -> anyhow::Result<()> {
         emit = EmitTarget::Exe;
     }
 
-    let bctx = BuildContext { use_color, emit };
+    let bctx = BuildContext {
+        use_color,
+        emit,
+        out_dir: std::env::current_dir().context("failed to get current directory")?,
+    };
     let bb = if let Source::File(path) = src {
         bbuild::BBuild::new(&path, bctx)
     } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,10 +1,17 @@
 use std::{
+    env,
+    fs,
     io::{
         self,
         IsTerminal,
     },
-    path::PathBuf,
+    path::{
+        Path,
+        PathBuf,
+    },
+    process,
     str::FromStr,
+    time,
 };
 
 use anyhow::Context;
@@ -158,10 +165,20 @@ fn main() -> anyhow::Result<()> {
         emit = EmitTarget::Exe;
     }
 
+    let mut _temp_dir_guard = None;
+    let out_dir = if let Subcommands::Run = subcommand {
+        let guard = TempDirGuard::new()?;
+        let path = guard.path.to_path_buf();
+        _temp_dir_guard = Some(guard);
+        path
+    } else {
+        env::current_dir().context("failed to get current directory")?
+    };
+
     let bctx = BuildContext {
         use_color,
         emit,
-        out_dir: std::env::current_dir().context("failed to get current directory")?,
+        out_dir,
     };
     let bb = if let Source::File(path) = src {
         bbuild::BBuild::new(&path, bctx)
@@ -227,4 +244,39 @@ fn run(bb: bbuild::BBuild) -> anyhow::Result<()> {
     bb.execute_artifact();
 
     Ok(())
+}
+
+struct TempDirGuard {
+    path: PathBuf,
+}
+
+impl TempDirGuard {
+    pub fn new() -> anyhow::Result<Self> {
+        let mut path = env::temp_dir();
+
+        let pid = process::id();
+        let nanos = time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
+        path.push(format!("belalang_out_{}_{}", pid, nanos));
+        fs::create_dir_all(&path)?;
+
+        Ok(Self { path })
+    }
+}
+
+impl std::ops::Deref for TempDirGuard {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.path
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
 }


### PR DESCRIPTION
The run subcommand now outputs compiler artifacts to a temporary directory instead of the current directory.

Closes #236 