### PR TITLE
[bir][birgen] Separate out autogenerated files

### DIFF
--- a/bir/birgen2/BIRGen2.cpp
+++ b/bir/birgen2/BIRGen2.cpp
@@ -6,4 +6,18 @@
 #include "belalang/BIRGen/BIRGen.h"
 
 #include "BIRGen2.h"
+
+namespace belalang {
+namespace birgen2 {
+
+std::unique_ptr<BIRGen2> create_birgen2(uintptr_t gen_ptr) {
+  auto *gen = reinterpret_cast<birgen::BIRGen *>(gen_ptr);
+  return std::make_unique<BIRGen2>(*gen);
+}
+
+BIRGen2::BIRGen2(::belalang::birgen::BIRGen &gen) : gen(gen) {}
+
 #include "Bindings.cpp.inc"
+
+} // birgen2
+} // belalang

--- a/bir/birgen2/BIRGen2.h
+++ b/bir/birgen2/BIRGen2.h
@@ -8,6 +8,50 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Location.h"
 
+namespace belalang {
+
+// forward declaration
+namespace birgen {
+class BIRGen;
+} // namespace birgen
+
+namespace birgen2 {
+
+// -----------------------------------------------------------------------------
+// BIRGuard
+// -----------------------------------------------------------------------------
+
+class BIRGuard {
+public:
+  BIRGuard(mlir::OpBuilder &builder) : guard(builder), builder(builder) {}
+  virtual ~BIRGuard() = default;
+
+protected:
+  mlir::OpBuilder::InsertionGuard guard;
+  mlir::OpBuilder &builder;
+};
+
+#define GET_BIRGUARD_CLASS_DECLS
 #include "Bindings.h.inc"
+
+// -----------------------------------------------------------------------------
+// BIRGen2
+// -----------------------------------------------------------------------------
+
+class BIRGen2 {
+public:
+  BIRGen2(birgen::BIRGen &gen);
+
+#define GET_BUILDER_FUNCTION_DECLS
+#include "Bindings.h.inc"
+
+private:
+  birgen::BIRGen &gen;
+};
+
+std::unique_ptr<BIRGen2> create_birgen2(uintptr_t gen);
+
+} // namespace birgen2
+} // namespace belalang
 
 #endif // BELALANG_BIRGEN2_BIRGEN2_H_

--- a/bir/tools/bir-tblgen/CXXBindingDecls.cpp
+++ b/bir/tools/bir-tblgen/CXXBindingDecls.cpp
@@ -77,54 +77,27 @@ void emitAndGather(const llvm::Record *opRec, llvm::raw_ostream &os) {
 }
 
 void emitBIRGenClass(llvm::raw_ostream &os) {
-  os << "class BIRGen2 {\n"
-     << "public:\n"
-     << "  BIRGen2(::belalang::birgen::BIRGen &gen);\n"
-     << "  ~BIRGen2() = default;\n";
+  os << "#ifdef GET_BUILDER_FUNCTION_DECLS\n"
+     << "#undef GET_BUILDER_FUNCTION_DECLS\n";
 
   for (auto decl : builderFunctionDecls)
     os << decl << "\n";
 
-  os << "private:\n"
-     << "  ::belalang::birgen::BIRGen &gen;\n"
-     << "};\n"
-     << "std::unique_ptr<BIRGen2> create_birgen2(uintptr_t gen);\n";
+  os << "#endif // GET_BUILDER_FUNCTION_DECLS\n";
 }
 
 } // namespace
 
-static const char *const BIRGenForwardDecl = R"(
-namespace belalang {
-namespace birgen {
-class BIRGen;
-} // namespace birgen
-} // namespace belalang
-)";
-
-static const char *const BIRGuardBaseClass = R"(
-class BIRGuard {
-public:
-  BIRGuard(mlir::OpBuilder &builder) : guard(builder), builder(builder) {}
-  virtual ~BIRGuard() = default;
-
-protected:
-  mlir::OpBuilder::InsertionGuard guard;
-  mlir::OpBuilder &builder;
-};
-)";
-
 namespace belalang::bir {
 
 void emitCXXBindingDecls(const llvm::RecordKeeper &rk, llvm::raw_ostream &os) {
-  os << BIRGenForwardDecl;
-  os << "namespace belalang::birgen2 {\n";
-  os << BIRGuardBaseClass;
-
+  os << "#ifdef GET_BIRGUARD_CLASS_DECLS\n"
+     << "#undef GET_BIRGUARD_CLASS_DECLS\n";
   for (const auto *op : rk.getAllDerivedDefinitions("BIR_Op"))
     emitAndGather(op, os);
-  emitBIRGenClass(os);
+  os << "#endif // GET_BIRGUARD_CLASS_DECLS\n";
 
-  os << "} // namespace belalang::birgen2\n";
+  emitBIRGenClass(os);
 }
 
 } // namespace belalang::bir

--- a/bir/tools/bir-tblgen/CXXBindingDefs.cpp
+++ b/bir/tools/bir-tblgen/CXXBindingDefs.cpp
@@ -68,27 +68,11 @@ void emit(const llvm::Record *opRec, llvm::raw_ostream &os) {
 
 } // namespace
 
-static const char *const CreateBIRGen2 = R"(
-std::unique_ptr<BIRGen2> create_birgen2(uintptr_t gen_ptr) {
-  auto *gen = reinterpret_cast<::belalang::birgen::BIRGen *>(gen_ptr);
-  return std::make_unique<BIRGen2>(*gen);
-}
-)";
-
-static const char *const BIRGen2Ctor = R"(
-BIRGen2::BIRGen2(::belalang::birgen::BIRGen &gen) : gen(gen) {}
-)";
-
 namespace belalang::bir {
 
 void emitCXXBindingDefs(const llvm::RecordKeeper &rk, llvm::raw_ostream &os) {
-  os << "namespace belalang::birgen2 {\n"
-     << CreateBIRGen2 << BIRGen2Ctor << "\n";
-
   for (const auto *op : rk.getAllDerivedDefinitions("BIR_Op"))
     emit(op, os);
-
-  os << "} // namespace belalang::birgen2\n";
 }
 
 } // namespace belalang::bir


### PR DESCRIPTION
The generated file `Bindings.cpp.inc` and `Bindings.h.inc` were full on C++ and header files. While convenient it made it really coupled with namespace hierarchy. This change makes it so that the generated files are for parts of C++ and header file and it is included to a "templated" C++ and header file. This is the pattern I see in LLVM codebase.