### PR TITLE
[bir] Implement bitwise ops

### DIFF
--- a/bir/include/belalang/BIR/IR/BIROps.td
+++ b/bir/include/belalang/BIR/IR/BIROps.td
@@ -175,6 +175,28 @@ def BIR_XorOp : BIR_Op<"xor"> {
   let hasBIRGenBindings = false; // TODO: make bindings
 }
 
+def BIR_ShlOp : BIR_Op<"shl"> {
+  let summary = "shl";
+
+  let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
+  let results = (outs BIR_AnyType:$result);
+
+  let assemblyFormat =
+      "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let hasBIRGenBindings = false; // TODO: make bindings
+}
+
+def BIR_ShrOp : BIR_Op<"shr"> {
+  let summary = "shr";
+
+  let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
+  let results = (outs BIR_AnyType:$result);
+
+  let assemblyFormat =
+      "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let hasBIRGenBindings = false; // TODO: make bindings
+}
+
 def BIR_PrintOp : BIR_Op<"print"> {
   let summary = "print";
 

--- a/bir/include/belalang/BIR/IR/BIROps.td
+++ b/bir/include/belalang/BIR/IR/BIROps.td
@@ -142,6 +142,39 @@ def BIR_ModOp : BIR_Op<"mod"> {
   let hasBIRGenBindings = false; // TODO: make bindings
 }
 
+def BIR_AndOp : BIR_Op<"and"> {
+  let summary = "and";
+
+  let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
+  let results = (outs BIR_AnyType:$result);
+
+  let assemblyFormat =
+      "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let hasBIRGenBindings = false; // TODO: make bindings
+}
+
+def BIR_OrOp : BIR_Op<"or"> {
+  let summary = "or";
+
+  let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
+  let results = (outs BIR_AnyType:$result);
+
+  let assemblyFormat =
+      "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let hasBIRGenBindings = false; // TODO: make bindings
+}
+
+def BIR_XorOp : BIR_Op<"xor"> {
+  let summary = "xor";
+
+  let arguments = (ins BIR_AnyType:$lhs, BIR_AnyType:$rhs);
+  let results = (outs BIR_AnyType:$result);
+
+  let assemblyFormat =
+      "$lhs `,` $rhs `:` functional-type(operands, results) attr-dict";
+  let hasBIRGenBindings = false; // TODO: make bindings
+}
+
 def BIR_PrintOp : BIR_Op<"print"> {
   let summary = "print";
 

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -368,6 +368,49 @@ struct XorOpLowering final : public OpConversionPattern<bir::XorOp> {
   }
 };
 
+struct ShlOpLowering final : public OpConversionPattern<bir::ShlOp> {
+  using OpConversionPattern<bir::ShlOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(bir::ShlOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto type = getTypeConverter()->convertType(op.getType());
+    if (!type)
+      return failure();
+
+    if (mlir::isa<mlir::IntegerType>(type)) {
+      rewriter.replaceOpWithNewOp<LLVM::ShlOp>(op, type, adaptor.getLhs(),
+                                               adaptor.getRhs());
+    } else {
+      return failure();
+    }
+
+    return success();
+  }
+};
+
+struct ShrOpLowering final : public OpConversionPattern<bir::ShrOp> {
+  using OpConversionPattern<bir::ShrOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(bir::ShrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto type = getTypeConverter()->convertType(op.getType());
+    if (!type)
+      return failure();
+
+    if (mlir::isa<mlir::IntegerType>(type)) {
+      // TODO: lshr? we currently only use signed integers
+      rewriter.replaceOpWithNewOp<LLVM::AShrOp>(op, type, adaptor.getLhs(),
+                                                adaptor.getRhs());
+    } else {
+      return failure();
+    }
+
+    return success();
+  }
+};
+
 struct VarDeclareOpLowering final : public OpConversionPattern<bir::VarDeclareOp> {
   using OpConversionPattern<bir::VarDeclareOp>::OpConversionPattern;
 
@@ -578,10 +621,10 @@ void belalang::bir::populateBelalangBIRToLLVMPatterns(
   patterns.add<ConstantOpLowering, FuncOpLowering, CallOpLowering,
                CallIndirectOpLowering, ReturnOpLowering, AddOpLowering,
                SubOpLowering, MulOpLowering, DivOpLowering, ModOpLowering,
-               AndOpLowering, OrOpLowering, XorOpLowering,
-               VarDeclareOpLowering, VarStoreOpLowering, VarLoadOpLowering,
-               CondBrLowering, CmpOpLowering>(typeConverter,
-                                              patterns.getContext());
+               AndOpLowering, OrOpLowering, XorOpLowering, ShlOpLowering,
+               ShrOpLowering, VarDeclareOpLowering, VarStoreOpLowering,
+               VarLoadOpLowering, CondBrLowering, CmpOpLowering>(
+      typeConverter, patterns.getContext());
 }
 
 // -----------------------------------------------------------------------------

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -305,6 +305,69 @@ struct ModOpLowering final : public OpConversionPattern<bir::ModOp> {
   }
 };
 
+struct AndOpLowering final : public OpConversionPattern<bir::AndOp> {
+  using OpConversionPattern<bir::AndOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(bir::AndOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto type = getTypeConverter()->convertType(op.getType());
+    if (!type)
+      return failure();
+
+    if (mlir::isa<mlir::IntegerType>(type)) {
+      rewriter.replaceOpWithNewOp<LLVM::AndOp>(op, type, adaptor.getLhs(),
+                                               adaptor.getRhs());
+    } else {
+      return failure();
+    }
+
+    return success();
+  }
+};
+
+struct OrOpLowering final : public OpConversionPattern<bir::OrOp> {
+  using OpConversionPattern<bir::OrOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(bir::OrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto type = getTypeConverter()->convertType(op.getType());
+    if (!type)
+      return failure();
+
+    if (mlir::isa<mlir::IntegerType>(type)) {
+      rewriter.replaceOpWithNewOp<LLVM::OrOp>(op, type, adaptor.getLhs(),
+                                              adaptor.getRhs());
+    } else {
+      return failure();
+    }
+
+    return success();
+  }
+};
+
+struct XorOpLowering final : public OpConversionPattern<bir::XorOp> {
+  using OpConversionPattern<bir::XorOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(bir::XorOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto type = getTypeConverter()->convertType(op.getType());
+    if (!type)
+      return failure();
+
+    if (mlir::isa<mlir::IntegerType>(type)) {
+      rewriter.replaceOpWithNewOp<LLVM::XOrOp>(op, type, adaptor.getLhs(),
+                                               adaptor.getRhs());
+    } else {
+      return failure();
+    }
+
+    return success();
+  }
+};
+
 struct VarDeclareOpLowering final : public OpConversionPattern<bir::VarDeclareOp> {
   using OpConversionPattern<bir::VarDeclareOp>::OpConversionPattern;
 
@@ -515,6 +578,7 @@ void belalang::bir::populateBelalangBIRToLLVMPatterns(
   patterns.add<ConstantOpLowering, FuncOpLowering, CallOpLowering,
                CallIndirectOpLowering, ReturnOpLowering, AddOpLowering,
                SubOpLowering, MulOpLowering, DivOpLowering, ModOpLowering,
+               AndOpLowering, OrOpLowering, XorOpLowering,
                VarDeclareOpLowering, VarStoreOpLowering, VarLoadOpLowering,
                CondBrLowering, CmpOpLowering>(typeConverter,
                                               patterns.getContext());

--- a/tests/BIR/IR/arith.mlir
+++ b/tests/BIR/IR/arith.mlir
@@ -9,5 +9,8 @@ bir.func @basic() -> !bir.int {
     %4 = bir.mul %0, %1 : (!bir.int, !bir.int) -> !bir.int
     %5 = bir.div %0, %1 : (!bir.int, !bir.int) -> !bir.int
     %6 = bir.mod %0, %1 : (!bir.int, !bir.int) -> !bir.int
+    %7 = bir.and %0, %1 : (!bir.int, !bir.int) -> !bir.int
+    %8 = bir.or %0, %1 : (!bir.int, !bir.int) -> !bir.int
+    %9 = bir.xor %0, %1 : (!bir.int, !bir.int) -> !bir.int
     bir.return %0 : !bir.int
 }

--- a/tests/BIR/IR/arith.mlir
+++ b/tests/BIR/IR/arith.mlir
@@ -12,5 +12,7 @@ bir.func @basic() -> !bir.int {
     %7 = bir.and %0, %1 : (!bir.int, !bir.int) -> !bir.int
     %8 = bir.or %0, %1 : (!bir.int, !bir.int) -> !bir.int
     %9 = bir.xor %0, %1 : (!bir.int, !bir.int) -> !bir.int
+    %10 = bir.shl %0, %1 : (!bir.int, !bir.int) -> !bir.int
+    %11 = bir.shr %0, %1 : (!bir.int, !bir.int) -> !bir.int
     bir.return %0 : !bir.int
 }

--- a/tests/BIR/Transforms/BIRToLLVM/arith.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/arith.mlir
@@ -34,6 +34,12 @@ bir.func @basic() -> !bir.int {
   // CHECK-NEXT: %9 = llvm.xor %0, %1 : i64
   %9 = bir.xor %0, %1 : (!bir.int, !bir.int) -> !bir.int
 
+  // CHECK-NEXT: %10 = llvm.shl %0, %1 : i64
+  %10 = bir.shl %0, %1 : (!bir.int, !bir.int) -> !bir.int
+
+  // CHECK-NEXT: %11 = llvm.ashr %0, %1 : i64
+  %11 = bir.shr %0, %1 : (!bir.int, !bir.int) -> !bir.int
+
   // CHECK-NEXT: llvm.return %0 : i64
   bir.return %0 : !bir.int
 }

--- a/tests/BIR/Transforms/BIRToLLVM/arith.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/arith.mlir
@@ -25,6 +25,15 @@ bir.func @basic() -> !bir.int {
   // CHECK-NEXT: %6 = llvm.srem %0, %1 : i64
   %6 = bir.mod %0, %1 : (!bir.int, !bir.int) -> !bir.int
 
+  // CHECK-NEXT: %7 = llvm.and %0, %1 : i64
+  %7 = bir.and %0, %1 : (!bir.int, !bir.int) -> !bir.int
+
+  // CHECK-NEXT: %8 = llvm.or %0, %1 : i64
+  %8 = bir.or %0, %1 : (!bir.int, !bir.int) -> !bir.int
+
+  // CHECK-NEXT: %9 = llvm.xor %0, %1 : i64
+  %9 = bir.xor %0, %1 : (!bir.int, !bir.int) -> !bir.int
+
   // CHECK-NEXT: llvm.return %0 : i64
   bir.return %0 : !bir.int
 }


### PR DESCRIPTION
The shift right is lowered to ashr because we're currently exclusively using signed integers. The `CmpOp` is also lowered to `slt`, `sle`, etc.

Closes #249 