### PR TITLE
[tests] Ungroup tests to many targets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,7 +14,7 @@ build --extra_toolchains=@llvm//toolchain:all
 build --@llvm//config:empty_sysroot=True
 build --@llvm//config:experimental_stub_libgcc_s=True
 
-test --test_output=all
+test --test_output=errors
 
 # Workaround: Rust nightly's libstd weakly references gettid (glibc >= 2.30),
 # but the hermetic LLVM toolchain ships glibc 2.28 stubs missing this symbol.

--- a/tests/BIR/Transforms/BIRToLLVM/BUILD.bazel
+++ b/tests/BIR/Transforms/BIRToLLVM/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//tests:lit.bzl", "lit_test")
 
-MLIR_TESTS = glob(["**/*.mlir"])
+MLIR_TESTS = glob(["*.mlir"])
 
 lit_test(
     name = "lit_test",

--- a/tests/BIR/Transforms/FlattenCFG/BUILD.bazel
+++ b/tests/BIR/Transforms/FlattenCFG/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tests:lit.bzl", "lit_test")
+
+MLIR_TESTS = glob(["*.mlir"])
+
+lit_test(
+    name = "lit_test",
+    tests = MLIR_TESTS,
+    data = [
+        "//bir:bir-opt",
+    ],
+    env = {
+        "BIR_OPT": "$(rlocationpath //bir:bir-opt)",
+    },
+)

--- a/tests/BIR/Transforms/LowerFuncExpr/BUILD.bazel
+++ b/tests/BIR/Transforms/LowerFuncExpr/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tests:lit.bzl", "lit_test")
+
+MLIR_TESTS = glob(["*.mlir"])
+
+lit_test(
+    name = "lit_test",
+    tests = MLIR_TESTS,
+    data = [
+        "//bir:bir-opt",
+    ],
+    env = {
+        "BIR_OPT": "$(rlocationpath //bir:bir-opt)",
+    },
+)

--- a/tests/BIR/Transforms/LowerPrintToRuntime/BUILD.bazel
+++ b/tests/BIR/Transforms/LowerPrintToRuntime/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tests:lit.bzl", "lit_test")
+
+MLIR_TESTS = glob(["*.mlir"])
+
+lit_test(
+    name = "lit_test",
+    tests = MLIR_TESTS,
+    data = [
+        "//bir:bir-opt",
+    ],
+    env = {
+        "BIR_OPT": "$(rlocationpath //bir:bir-opt)",
+    },
+)

--- a/tests/BIR/Transforms/PrepareRuntime/BUILD.bazel
+++ b/tests/BIR/Transforms/PrepareRuntime/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tests:lit.bzl", "lit_test")
+
+MLIR_TESTS = glob(["*.mlir"])
+
+lit_test(
+    name = "lit_test",
+    tests = MLIR_TESTS,
+    data = [
+        "//bir:bir-opt",
+    ],
+    env = {
+        "BIR_OPT": "$(rlocationpath //bir:bir-opt)",
+    },
+)

--- a/tests/lit.bzl
+++ b/tests/lit.bzl
@@ -2,20 +2,30 @@ load("@pypi//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
 
 def lit_test(name, tests, data = [], env = {}, **kwargs):
-    py_test(
+    individual_targets = []
+    for test in tests:
+        target_name = test.replace(".", "_").replace("/", "_")
+
+        py_test(
+            name = target_name,
+            srcs = ["//tests:run_lit.py"],
+            main = "//tests:run_lit.py",
+            args = ["$(execpath %s)" % test],
+            data = [test] + data + [
+                "//tests:lit.cfg.py",
+                "@llvm-project//llvm:FileCheck",
+                "@llvm-project//llvm:not",
+            ],
+            env = dict({
+                "FILECHECK": "$(rlocationpath @llvm-project//llvm:FileCheck)",
+                "NOT": "$(rlocationpath @llvm-project//llvm:not)",
+            }, **env),
+            deps = [requirement("lit")],
+            **kwargs
+        )
+        individual_targets.append(":" + target_name)
+
+    native.test_suite(
         name = name,
-        srcs = ["//tests:run_lit.py"],
-        main = "//tests:run_lit.py",
-        args = ["$(execpath %s)" % f for f in tests],
-        data = tests + data + [
-            "//tests:lit.cfg.py",
-            "@llvm-project//llvm:FileCheck",
-            "@llvm-project//llvm:not",
-        ],
-        env = dict({
-            "FILECHECK": "$(rlocationpath @llvm-project//llvm:FileCheck)",
-            "NOT": "$(rlocationpath @llvm-project//llvm:not)",
-        }, **env),
-        deps = [requirement("lit")],
-        **kwargs
+        tests = individual_targets,
     )


### PR DESCRIPTION
Previously, the tests were grouped into one target per directory. This made it quite difficult to see which tests are failing and why. For example, if one test failed in the BIRToLLVM pipeline, all of the BIRToLLVM tests failed. With this, hopefully tests are easier to view.