### PR TITLE
[bir][birgen] Use ScopeOp inside WhileOp

### DIFF
--- a/bir/include/belalang/BIR/IR/BIROps.td
+++ b/bir/include/belalang/BIR/IR/BIROps.td
@@ -389,7 +389,7 @@ def BIR_ScopeOp : BIR_Op<"scope", [
 }
 
 def BIR_YieldOp : BIR_Op<"yield", [
-  ParentOneOf<["ScopeOp", "IfOp"]>,
+  ParentOneOf<["ScopeOp", "IfOp", "WhileOp"]>,
   Terminator,
 ]> {
   let summary = "yield";
@@ -414,6 +414,7 @@ def BIR_IfOp : BIR_Op<"if", [
 
   let extraClassDeclaration = [{
     bool hasElse() { return !getElseRegion().empty(); }
+    static LogicalResult ensureRegionTerm(::mlir::Builder &, ::mlir::Region &);
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/bir/lib/IR/BIROps.cpp
+++ b/bir/lib/IR/BIROps.cpp
@@ -210,6 +210,22 @@ void CallOp::setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
 // IfOp
 // -----------------------------------------------------------------------------
 
+mlir::LogicalResult IfOp::ensureRegionTerm(mlir::Builder &b, mlir::Region &r) {
+  mlir::OpBuilder builder(b.getContext());
+
+  if (r.empty())
+    builder.createBlock(&r);
+
+  mlir::Block &blk = r.back();
+  if (!blk.empty() && blk.back().hasTrait<OpTrait::IsTerminator>())
+    return success();
+
+  // Create the yield op to terminate the block
+  builder.setInsertionPointToEnd(&blk);
+  bir::YieldOp::create(builder, builder.getUnknownLoc());
+  return success();
+}
+
 mlir::ParseResult IfOp::parse(mlir::OpAsmParser &p, mlir::OperationState &result) {
   result.regions.reserve(2);
   mlir::Region *thenRegion = result.addRegion();
@@ -223,9 +239,13 @@ mlir::ParseResult IfOp::parse(mlir::OpAsmParser &p, mlir::OperationState &result
 
   if (failed(p.parseRegion(*thenRegion)))
     return failure();
+  if (failed(ensureRegionTerm(p.getBuilder(), *thenRegion)))
+    return failure();
 
   if (succeeded(p.parseOptionalKeyword("else"))) {
     if (failed(p.parseRegion(*elseRegion)))
+      return failure();
+    if (failed(ensureRegionTerm(p.getBuilder(), *elseRegion)))
       return failure();
   }
 

--- a/bir/lib/Transforms/FlattenCFG.cpp
+++ b/bir/lib/Transforms/FlattenCFG.cpp
@@ -151,13 +151,12 @@ public:
       }
     });
 
-    // End body with jump to condition.
-    {
-      OpBuilder::InsertionGuard guard(rewriter);
-      rewriter.setInsertionPointToEnd(&op.getBody().back());
-      if (auto continueOp =
-              dyn_cast<bir::ContinueOp>(op.getBody().back().getTerminator()))
-        rewriter.replaceOpWithNewOp<cf::BranchOp>(continueOp, cond);
+    // Lower yield terminator.
+    for (mlir::Block &blk : op.getBody().getBlocks()) {
+      if (auto yield = dyn_cast<bir::YieldOp>(blk.getTerminator())) {
+        rewriter.setInsertionPointToEnd(&op.getBody().back());
+        rewriter.replaceOpWithNewOp<cf::BranchOp>(yield, cond);
+      }
     }
 
     // Inline contents.

--- a/birgen/include/belalang/BIRGen/BIRGen.h
+++ b/birgen/include/belalang/BIRGen/BIRGen.h
@@ -105,7 +105,7 @@ public:
              mlir::Region *elseRegion, mlir::Value resultValue)
       : BIRGuard(builder), thenRegion(thenRegion), elseRegion(elseRegion),
         resultValue(resultValue) {}
-  ~BIRIfGuard() = default;
+  ~BIRIfGuard();
 
   void start_then();
   void start_else();

--- a/birgen/lib/BIRGen.cpp
+++ b/birgen/lib/BIRGen.cpp
@@ -195,6 +195,12 @@ BIRGen::build_fn_expr(TypeKind resultTy, rust::Slice<const TypeKind> paramTys) {
   return guard;
 }
 
+BIRIfGuard::~BIRIfGuard() {
+  // TODO: handle errors, for now, it won't error
+  assert(bir::IfOp::ensureRegionTerm(builder, *thenRegion).succeeded());
+  assert(bir::IfOp::ensureRegionTerm(builder, *elseRegion).succeeded());
+}
+
 void BIRIfGuard::start_then() {
   thenRegion->push_back(new mlir::Block());
   builder.setInsertionPointToEnd(&thenRegion->front());

--- a/birgen/src/lib.rs
+++ b/birgen/src/lib.rs
@@ -155,10 +155,14 @@ impl<'sess> BIRGen<'sess> {
                 self.inner.pin_mut().build_condition(&cond_val);
 
                 guard.pin_mut().enter_body();
+                let mut bg = self.inner.pin_mut().build_block_expr();
+                bg.pin_mut().start_body();
                 for stmt in while_stmt.block.statements {
                     self.generate_statement(stmt);
                 }
-                self.bir_codegen.pin_mut().build_continue_op();
+                self.inner.pin_mut().build_empty_yield();
+                drop(bg);
+                self.inner.pin_mut().build_empty_yield();
             },
             Statement::VarDecl(var) => {
                 let value = &var.value;
@@ -340,7 +344,6 @@ impl<'sess> BIRGen<'sess> {
                 for stmt in if_expr.consequence.statements {
                     self.generate_statement(stmt);
                 }
-                self.inner.pin_mut().build_empty_yield();
 
                 if let Some(alt) = if_expr.alternative {
                     guard.pin_mut().start_else();
@@ -354,7 +357,6 @@ impl<'sess> BIRGen<'sess> {
                             self.generate_expression(alt);
                         },
                     }
-                    self.inner.pin_mut().build_empty_yield();
                 }
 
                 guard.get_value()

--- a/tests/BIR/IR/if-op.mlir
+++ b/tests/BIR/IR/if-op.mlir
@@ -3,6 +3,7 @@
 bir.func @main() {
   %0 = bir.constant #bir.bool<true> : !bir.bool
   // CHECK:      bir.if %{{.*}} {
+  // CHECK-NEXT:   bir.yield
   // CHECK-NEXT: }
   bir.if %0 {}
   bir.return

--- a/tests/BIRGen/conditionals.bel
+++ b/tests/BIRGen/conditionals.bel
@@ -8,17 +8,19 @@
 # CHECK-NEXT:     bir.cond_br %[[C1]] ^bb1, ^bb2
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0
 # CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT:     cf.br ^bb2
-# CHECK-NEXT:   ^bb2:  // 2 preds: ^bb0, ^bb1
+# CHECK-NEXT:     cf.br ^bb3
+# CHECK-NEXT:   ^bb2:  // pred: ^bb0
+# CHECK-NEXT:     cf.br ^bb3
+# CHECK-NEXT:   ^bb3:  // 2 preds: ^bb1, ^bb2
 # CHECK-NEXT:     %[[C3:.*]] = bir.constant #bir.bool<false> : !bir.bool
-# CHECK-NEXT:     bir.cond_br %[[C3]] ^bb3, ^bb4
-# CHECK-NEXT:   ^bb3:  // pred: ^bb2
+# CHECK-NEXT:     bir.cond_br %[[C3]] ^bb4, ^bb5
+# CHECK-NEXT:   ^bb4:  // pred: ^bb3
 # CHECK-NEXT:     %[[C4:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT:     cf.br ^bb5
-# CHECK-NEXT:   ^bb4:  // pred: ^bb2
+# CHECK-NEXT:     cf.br ^bb6
+# CHECK-NEXT:   ^bb5:  // pred: ^bb3
 # CHECK-NEXT:     %[[C5:.*]] = bir.constant #bir.int<0> : !bir.int
-# CHECK-NEXT:     cf.br ^bb5
-# CHECK-NEXT:   ^bb5:  // 2 preds: ^bb3, ^bb4
+# CHECK-NEXT:     cf.br ^bb6
+# CHECK-NEXT:   ^bb6:  // 2 preds: ^bb4, ^bb5
 # CHECK-NEXT:     %[[C6:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C6]] : !bir.int
 # CHECK-NEXT:   }

--- a/tests/BIRGen/while-loops.bel
+++ b/tests/BIRGen/while-loops.bel
@@ -8,18 +8,22 @@
 # CHECK-NEXT:     %[[X:.*]] = bir.var.declare "x" : <!bir.int>
 # CHECK-NEXT:     bir.var.store %[[C0]] to %[[X]] : !bir.int to <!bir.int>
 # CHECK-NEXT:     cf.br ^bb1
-# CHECK-NEXT:   ^bb1:  // 2 preds: ^bb0, ^bb2
+# CHECK-NEXT:   ^bb1:  // 2 preds: ^bb0, ^bb4
 # CHECK-NEXT:     %[[L1:.*]] = bir.var.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     %[[C5:.*]] = bir.constant #bir.int<5> : !bir.int
 # CHECK-NEXT:     %[[COND:.*]] = bir.cmp lt %[[L1]], %[[C5]] : !bir.int
-# CHECK-NEXT:     bir.cond_br %[[COND]] ^bb2, ^bb3
+# CHECK-NEXT:     bir.cond_br %[[COND]] ^bb2, ^bb5
 # CHECK-NEXT:   ^bb2:  // pred: ^bb1
+# CHECK-NEXT:     cf.br ^bb3
+# CHECK-NEXT:   ^bb3:  // pred: ^bb2
 # CHECK-NEXT:     %[[C1:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT:     %[[L2:.*]] = bir.var.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     %[[ADD:.*]] = bir.add %[[L2]], %[[C1]] : (!bir.int, !bir.int) -> !bir.int
 # CHECK-NEXT:     bir.var.store %[[ADD]] to %[[X]] : !bir.int to <!bir.int>
+# CHECK-NEXT:     cf.br ^bb4
+# CHECK-NEXT:   ^bb4:  // pred: ^bb3
 # CHECK-NEXT:     cf.br ^bb1
-# CHECK-NEXT:   ^bb3:  // pred: ^bb1
+# CHECK-NEXT:   ^bb5:  // pred: ^bb1
 # CHECK-NEXT:     %[[C0_RET:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C0_RET]] : !bir.int
 # CHECK-NEXT:   }


### PR DESCRIPTION
Previously, the WhileOp emits the body directly. This makes it difficult to use other ops as the while block terminator. With this new configuration, WhileOp has a ScopeOp inside it which enables the WhileOp to have the yield terminator while the other terminator is inside ScopeOp.