### PR TITLE
[ast] Add Span to AST nodes

### DIFF
--- a/ast/src/expressions.rs
+++ b/ast/src/expressions.rs
@@ -4,6 +4,7 @@ use lexer::{
     PrefixKind,
 };
 use session::interner::Symbol;
+use span::SourceSpan;
 
 use super::{
     Statement,
@@ -208,7 +209,13 @@ pub struct BlockExpression<'ast> {
 
 /// Represents all expressions supported by The Belalang Compiler.
 #[derive(Debug, Clone, Copy)]
-pub enum Expression<'ast> {
+pub struct Expression<'ast> {
+    pub kind: ExpressionKind<'ast>,
+    pub span: SourceSpan,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ExpressionKind<'ast> {
     Boolean(BooleanExpression),
     Integer(IntegerLiteral),
     Float(FloatLiteral),

--- a/ast/src/parser.rs
+++ b/ast/src/parser.rs
@@ -12,11 +12,14 @@ use lexer::{
     TokenKind,
 };
 use session::Session;
+use span::SourceSpan;
 
 use super::{
     Expression,
+    ExpressionKind,
     ParserError,
     Statement,
+    StatementKind,
 };
 use crate::{
     ArrayLiteral,
@@ -165,6 +168,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     }
 
     fn parse_statement(&mut self) -> Result<Statement<'ast>, ParserError> {
+        let start_span = self.curr_token.span;
         match self.curr_token.kind {
             // matches `return`
             TokenKind::Return => {
@@ -180,8 +184,12 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 };
 
                 self.has_semicolon = optional_peek!(self, TokenKind::Semicolon);
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
 
-                Ok(Statement::Return(ReturnStatement { return_value }))
+                Ok(Statement {
+                    kind: StatementKind::Return(ReturnStatement { return_value }),
+                    span,
+                })
             },
 
             // parse_while
@@ -194,23 +202,37 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let block = self.parse_block()?;
 
                 self.has_semicolon = optional_peek!(self, TokenKind::Semicolon);
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
 
-                Ok(Statement::While(WhileStatement { condition, block }))
+                Ok(Statement {
+                    kind: StatementKind::While(WhileStatement { condition, block }),
+                    span,
+                })
             },
 
             // match `break`
-            TokenKind::KwBreak => Ok(Statement::Break(BreakStatement)),
+            TokenKind::KwBreak => Ok(Statement {
+                kind: StatementKind::Break(BreakStatement),
+                span: start_span,
+            }),
 
             // match `continue`
-            TokenKind::KwContinue => Ok(Statement::Continue(ContinueStatement)),
+            TokenKind::KwContinue => Ok(Statement {
+                kind: StatementKind::Continue(ContinueStatement),
+                span: start_span,
+            }),
 
             // parse_if: parse if expression as statement
             TokenKind::If => {
                 let expression = *self.parse_if()?;
 
                 self.has_semicolon = optional_peek!(self, TokenKind::Semicolon);
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
 
-                Ok(Statement::Expression(ExpressionStatement { expression }))
+                Ok(Statement {
+                    kind: StatementKind::Expression(ExpressionStatement { expression }),
+                    span,
+                })
             },
 
             // matches `<ident> :`
@@ -256,12 +278,16 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 };
 
                 self.has_semicolon = optional_peek!(self, TokenKind::Semicolon);
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
 
-                Ok(*self.ast.alloc(Statement::VarDecl(VarDeclStatement {
-                    name,
-                    value,
-                    explicit_ty,
-                })))
+                Ok(*self.ast.alloc(Statement {
+                    kind: StatementKind::VarDecl(VarDeclStatement {
+                        name,
+                        value,
+                        explicit_ty,
+                    }),
+                    span,
+                }))
             },
 
             // matches `struct`
@@ -281,28 +307,35 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 self.depth += 1;
                 while !matches!(self.curr_token.kind, TokenKind::RightBrace | TokenKind::EOF) {
                     let stmt = self.parse_statement()?;
-                    let Statement::VarDecl(var_decl) = stmt else {
-                        return Err(self.error_parsing_struct());
+                    let StatementKind::VarDecl(var_decl) = stmt.kind else {
+                        return Err(self.error_parsing_struct(stmt));
                     };
                     fields.push(var_decl);
                     self.next_token()?; // curr_token now at next statement
                 } // curr_token now at end of block
                 self.depth -= 1;
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
 
-                Ok(*self.ast.alloc(Statement::StructDecl(StructDeclStatement {
-                    name: struct_name,
-                    fields: self.ast.alloc_slice_clone(&fields),
-                })))
+                Ok(*self.ast.alloc(Statement {
+                    kind: StatementKind::StructDecl(StructDeclStatement {
+                        name: struct_name,
+                        fields: self.ast.alloc_slice_clone(&fields),
+                    }),
+                    span,
+                }))
             },
 
             _ => {
-                let stmt = ExpressionStatement {
-                    expression: *self.parse_expression(Precedence::Lowest)?,
-                };
+                let expr = self.parse_expression(Precedence::Lowest)?;
+                let stmt = ExpressionStatement { expression: *expr };
 
                 self.has_semicolon = optional_peek!(self, TokenKind::Semicolon);
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
 
-                Ok(Statement::Expression(stmt))
+                Ok(Statement {
+                    kind: StatementKind::Expression(stmt),
+                    span,
+                })
             },
         }
     }
@@ -338,34 +371,52 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     }
 
     fn parse_if(&mut self) -> Result<&'ast Expression<'ast>, ParserError> {
+        let start_span = self.curr_token.span;
         self.next_token()?;
         let condition = self.parse_expression(Precedence::Lowest)?;
 
         expect_peek!(self, TokenKind::LeftBrace);
 
         let consequence = self.parse_block()?;
+        let mut end_span = self.curr_token.span;
 
         let alternative: Option<&'ast Expression<'ast>> = if matches!(self.peek_token.kind, TokenKind::Else) {
             self.next_token()?;
             self.next_token()?;
 
-            Some(match self.curr_token.kind {
+            let alt = match self.curr_token.kind {
                 TokenKind::If => self.parse_if()?,
-                TokenKind::LeftBrace => self.ast.alloc(Expression::Block(self.parse_block()?)),
+                TokenKind::LeftBrace => {
+                    let block_start = self.curr_token.span;
+                    let block = self.parse_block()?;
+                    let block_span = SourceSpan::new(block_start.start, self.curr_token.span.end);
+                    self.ast.alloc(Expression {
+                        kind: ExpressionKind::Block(block),
+                        span: block_span,
+                    })
+                },
                 _ => return Err(self.error_unexpected_token()),
-            })
+            };
+            end_span = alt.span;
+            Some(alt)
         } else {
             None
         };
 
-        Ok(self.ast.alloc(Expression::If(IfExpression {
-            condition,
-            consequence,
-            alternative,
-        })))
+        let span = SourceSpan::new(start_span.start, end_span.end);
+
+        Ok(self.ast.alloc(Expression {
+            kind: ExpressionKind::If(IfExpression {
+                condition,
+                consequence,
+                alternative,
+            }),
+            span,
+        }))
     }
 
     fn parse_infix(&mut self, left: &'ast Expression<'ast>) -> Result<Option<&'ast Expression<'ast>>, ParserError> {
+        let start_span = left.span;
         match self.peek_token.kind {
             // parse_infix: parse infix expression
             TokenKind::Add
@@ -394,32 +445,36 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 self.next_token()?;
 
                 let right = self.parse_expression(precedence)?;
+                let span = SourceSpan::new(start_span.start, right.span.end);
 
-                Ok(Some(self.ast.alloc(Expression::Infix(InfixExpression {
-                    left,
-                    operator: match operator.kind {
-                        TokenKind::Add => InfixKind::Add,
-                        TokenKind::Sub => InfixKind::Sub,
-                        TokenKind::Mul => InfixKind::Mul,
-                        TokenKind::Div => InfixKind::Div,
-                        TokenKind::Mod => InfixKind::Mod,
-                        TokenKind::Eq => InfixKind::Eq,
-                        TokenKind::Ne => InfixKind::Ne,
-                        TokenKind::Gt => InfixKind::Gt,
-                        TokenKind::Ge => InfixKind::Ge,
-                        TokenKind::Lt => InfixKind::Lt,
-                        TokenKind::Le => InfixKind::Le,
-                        TokenKind::BitAnd => InfixKind::BitAnd,
-                        TokenKind::BitOr => InfixKind::BitOr,
-                        TokenKind::BitXor => InfixKind::BitXor,
-                        TokenKind::ShiftLeft => InfixKind::ShiftLeft,
-                        TokenKind::ShiftRight => InfixKind::ShiftRight,
-                        TokenKind::Or => InfixKind::Or,
-                        TokenKind::And => InfixKind::And,
-                        _ => unreachable!(),
-                    },
-                    right,
-                }))))
+                Ok(Some(self.ast.alloc(Expression {
+                    kind: ExpressionKind::Infix(InfixExpression {
+                        left,
+                        operator: match operator.kind {
+                            TokenKind::Add => InfixKind::Add,
+                            TokenKind::Sub => InfixKind::Sub,
+                            TokenKind::Mul => InfixKind::Mul,
+                            TokenKind::Div => InfixKind::Div,
+                            TokenKind::Mod => InfixKind::Mod,
+                            TokenKind::Eq => InfixKind::Eq,
+                            TokenKind::Ne => InfixKind::Ne,
+                            TokenKind::Gt => InfixKind::Gt,
+                            TokenKind::Ge => InfixKind::Ge,
+                            TokenKind::Lt => InfixKind::Lt,
+                            TokenKind::Le => InfixKind::Le,
+                            TokenKind::BitAnd => InfixKind::BitAnd,
+                            TokenKind::BitOr => InfixKind::BitOr,
+                            TokenKind::BitXor => InfixKind::BitXor,
+                            TokenKind::ShiftLeft => InfixKind::ShiftLeft,
+                            TokenKind::ShiftRight => InfixKind::ShiftRight,
+                            TokenKind::Or => InfixKind::Or,
+                            TokenKind::And => InfixKind::And,
+                            _ => unreachable!(),
+                        },
+                        right,
+                    }),
+                    span,
+                })))
             },
 
             // parse_call: parse call expression
@@ -443,11 +498,15 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
                     expect_peek!(self, TokenKind::RightParen);
                 }
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
 
-                Ok(Some(self.ast.alloc(Expression::Call(CallExpression {
-                    function: left,
-                    args: self.ast.alloc_slice_clone(&args),
-                }))))
+                Ok(Some(self.ast.alloc(Expression {
+                    kind: ExpressionKind::Call(CallExpression {
+                        function: left,
+                        args: self.ast.alloc_slice_clone(&args),
+                    }),
+                    span,
+                })))
             },
 
             TokenKind::LeftBracket => {
@@ -457,13 +516,17 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let index = self.parse_expression(Precedence::Lowest)?;
 
                 expect_peek!(self, TokenKind::RightBracket);
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
 
-                Ok(Some(self.ast.alloc(Expression::Index(IndexExpression { left, index }))))
+                Ok(Some(self.ast.alloc(Expression {
+                    kind: ExpressionKind::Index(IndexExpression { left, index }),
+                    span,
+                })))
             },
 
             TokenKind::Assign { ref kind } => {
                 let kind = *kind;
-                if !matches!(left, Expression::Identifier(_)) {
+                if !matches!(left.kind, ExpressionKind::Identifier(_)) {
                     return Err(self.error_invalid_lhs(left));
                 }
 
@@ -477,12 +540,12 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
                 self.next_token()?;
                 let value = self.parse_expression(Precedence::Lowest)?;
+                let span = SourceSpan::new(start_span.start, value.span.end);
 
-                Ok(Some(self.ast.alloc(Expression::Var(VarExpression {
-                    kind,
-                    name,
-                    value,
-                }))))
+                Ok(Some(self.ast.alloc(Expression {
+                    kind: ExpressionKind::Var(VarExpression { kind, name, value }),
+                    span,
+                })))
             },
 
             _ => Ok(None),
@@ -490,28 +553,47 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     }
 
     fn parse_prefix(&mut self) -> Result<&'ast Expression<'ast>, ParserError> {
+        let start_span = self.curr_token.span;
         match self.curr_token.kind {
             // parse_identifier: parse current token as identifier
-            TokenKind::Ident { sym } => Ok(self.ast.alloc(Expression::Identifier(Identifier { value: sym }))),
+            TokenKind::Ident { sym } => Ok(self.ast.alloc(Expression {
+                kind: ExpressionKind::Identifier(Identifier { value: sym }),
+                span: start_span,
+            })),
 
             TokenKind::Literal { ref kind, sym } => {
                 let str_value = self.session.lookup_string(sym);
                 match kind {
                     LiteralKind::Integer => match str_value.parse::<i64>() {
-                        Ok(lit) => Ok(self.ast.alloc(Expression::Integer(IntegerLiteral { value: lit }))),
+                        Ok(lit) => Ok(self.ast.alloc(Expression {
+                            kind: ExpressionKind::Integer(IntegerLiteral { value: lit }),
+                            span: start_span,
+                        })),
                         Err(_) => Err(self.error_parsing_integer(str_value)),
                     },
                     LiteralKind::Float => match str_value.parse::<f64>() {
-                        Ok(lit) => Ok(self.ast.alloc(Expression::Float(FloatLiteral { value: lit }))),
+                        Ok(lit) => Ok(self.ast.alloc(Expression {
+                            kind: ExpressionKind::Float(FloatLiteral { value: lit }),
+                            span: start_span,
+                        })),
                         Err(_) => Err(self.error_parsing_float(str_value)),
                     },
-                    LiteralKind::String => Ok(self.ast.alloc(Expression::String(StringLiteral { value: sym }))),
+                    LiteralKind::String => Ok(self.ast.alloc(Expression {
+                        kind: ExpressionKind::String(StringLiteral { value: sym }),
+                        span: start_span,
+                    })),
                 }
             },
 
-            TokenKind::KwTrue => Ok(self.ast.alloc(Expression::Boolean(BooleanExpression { value: true }))),
+            TokenKind::KwTrue => Ok(self.ast.alloc(Expression {
+                kind: ExpressionKind::Boolean(BooleanExpression { value: true }),
+                span: start_span,
+            })),
 
-            TokenKind::KwFalse => Ok(self.ast.alloc(Expression::Boolean(BooleanExpression { value: false }))),
+            TokenKind::KwFalse => Ok(self.ast.alloc(Expression {
+                kind: ExpressionKind::Boolean(BooleanExpression { value: false }),
+                span: start_span,
+            })),
 
             // parse_array
             TokenKind::LeftBracket => {
@@ -533,10 +615,14 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
                     expect_peek!(self, TokenKind::RightBracket);
                 }
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
 
-                Ok(self.ast.alloc(Expression::Array(ArrayLiteral {
-                    elements: self.ast.alloc_slice_clone(&elements),
-                })))
+                Ok(self.ast.alloc(Expression {
+                    kind: ExpressionKind::Array(ArrayLiteral {
+                        elements: self.ast.alloc_slice_clone(&elements),
+                    }),
+                    span,
+                }))
             },
 
             // parse_prefix: parse current expression with prefix
@@ -546,15 +632,19 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 self.next_token()?;
 
                 let right = self.parse_expression(Precedence::Prefix).unwrap();
+                let span = SourceSpan::new(start_span.start, right.span.end);
 
-                Ok(self.ast.alloc(Expression::Prefix(PrefixExpression {
-                    operator: match prev_token.kind {
-                        TokenKind::Not => PrefixKind::Not,
-                        TokenKind::Sub => PrefixKind::Sub,
-                        _ => unreachable!(),
-                    },
-                    right,
-                })))
+                Ok(self.ast.alloc(Expression {
+                    kind: ExpressionKind::Prefix(PrefixExpression {
+                        operator: match prev_token.kind {
+                            TokenKind::Not => PrefixKind::Not,
+                            TokenKind::Sub => PrefixKind::Sub,
+                            _ => unreachable!(),
+                        },
+                        right,
+                    }),
+                    span,
+                }))
             },
 
             // parse_grouped: parse grouped expression
@@ -570,7 +660,11 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             // parse_block
             TokenKind::LeftBrace => {
                 let block = self.parse_block()?;
-                Ok(self.ast.alloc(Expression::Block(block)))
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
+                Ok(self.ast.alloc(Expression {
+                    kind: ExpressionKind::Block(block),
+                    span,
+                }))
             },
 
             // parse_if: parse current if expression
@@ -634,12 +728,16 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 expect_peek!(self, TokenKind::LeftBrace); // curr_token is now `{`
 
                 let body = self.parse_block()?;
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
 
-                Ok(self.ast.alloc(Expression::Function(FunctionLiteral {
-                    params: self.ast.alloc_slice_clone(&params),
-                    body,
-                    explicit_ty,
-                })))
+                Ok(self.ast.alloc(Expression {
+                    kind: ExpressionKind::Function(FunctionLiteral {
+                        params: self.ast.alloc_slice_clone(&params),
+                        body,
+                        explicit_ty,
+                    }),
+                    span,
+                }))
             },
 
             _ => Err(self.error_unknown_prefix_op()),
@@ -659,9 +757,8 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         ParserError::UnknownPrefixOperator(self.curr_token.kind)
     }
 
-    fn error_invalid_lhs(&self, _left: &Expression) -> ParserError {
-        // TODO: change this with expression span
-        let label = Label::primary(self.curr_token.span, "invalid lhs");
+    fn error_invalid_lhs(&self, left: &Expression) -> ParserError {
+        let label = Label::primary(left.span, "invalid lhs");
         self.session.emit(Diagnostic::error("invalid lhs").with_label(label));
         ParserError::InvalidLHS
     }
@@ -680,9 +777,8 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         ParserError::ParsingFloat(v.to_string())
     }
 
-    fn error_parsing_struct(&self) -> ParserError {
-        let label = Label::primary(self.curr_token.span, "invalid statement");
-        // TODO: fix diagnostic span regarding statement
+    fn error_parsing_struct(&self, stmt: Statement) -> ParserError {
+        let label = Label::primary(stmt.span, "invalid statement");
         self.session
             .emit(Diagnostic::error("error parsing struct").with_label(label));
         ParserError::ParsingStruct

--- a/ast/src/statements.rs
+++ b/ast/src/statements.rs
@@ -1,4 +1,5 @@
 use session::interner::Symbol;
+use span::SourceSpan;
 
 use super::{
     BlockExpression,
@@ -42,7 +43,13 @@ pub struct StructDeclStatement<'ast> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum Statement<'ast> {
+pub struct Statement<'ast> {
+    pub kind: StatementKind<'ast>,
+    pub span: SourceSpan,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum StatementKind<'ast> {
     Expression(ExpressionStatement<'ast>),
     Return(ReturnStatement<'ast>),
     While(WhileStatement<'ast>),

--- a/ast/src/visitor.rs
+++ b/ast/src/visitor.rs
@@ -6,6 +6,7 @@ use super::{
     CallExpression,
     ContinueStatement,
     Expression,
+    ExpressionKind,
     ExpressionStatement,
     FloatLiteral,
     FunctionLiteral,
@@ -19,6 +20,7 @@ use super::{
     Program,
     ReturnStatement,
     Statement,
+    StatementKind,
     StringLiteral,
     StructDeclStatement,
     VarDeclStatement,
@@ -118,34 +120,34 @@ pub trait Visitor<'ast> {
     }
 
     fn walk_statement(&mut self, stmt: &Statement<'ast>) {
-        match stmt {
-            Statement::Expression(v) => self.visit_expression_statement(v),
-            Statement::Return(v) => self.visit_return_statement(v),
-            Statement::While(v) => self.visit_while_statement(v),
-            Statement::VarDecl(v) => self.visit_var_decl_statement(v),
-            Statement::StructDecl(v) => self.visit_struct_decl_statement(v),
-            Statement::Break(v) => self.visit_break_statement(v),
-            Statement::Continue(v) => self.visit_continue_statement(v),
+        match &stmt.kind {
+            StatementKind::Expression(v) => self.visit_expression_statement(v),
+            StatementKind::Return(v) => self.visit_return_statement(v),
+            StatementKind::While(v) => self.visit_while_statement(v),
+            StatementKind::VarDecl(v) => self.visit_var_decl_statement(v),
+            StatementKind::StructDecl(v) => self.visit_struct_decl_statement(v),
+            StatementKind::Break(v) => self.visit_break_statement(v),
+            StatementKind::Continue(v) => self.visit_continue_statement(v),
         }
     }
 
     fn walk_expression(&mut self, expr: &Expression<'ast>) {
-        match expr {
-            Expression::Boolean(v) => self.visit_boolean(v),
-            Expression::Integer(v) => self.visit_integer(v),
-            Expression::Float(v) => self.visit_float(v),
-            Expression::String(v) => self.visit_string(v),
-            Expression::Null(v) => self.visit_null(v),
-            Expression::Array(v) => self.visit_array(v),
-            Expression::Var(v) => self.visit_var(v),
-            Expression::Call(v) => self.visit_call(v),
-            Expression::Index(v) => self.visit_index(v),
-            Expression::Function(v) => self.visit_function(v),
-            Expression::Identifier(v) => self.visit_identifier(v),
-            Expression::If(v) => self.visit_if(v),
-            Expression::Infix(v) => self.visit_infix(v),
-            Expression::Prefix(v) => self.visit_prefix(v),
-            Expression::Block(v) => self.visit_block(v),
+        match &expr.kind {
+            ExpressionKind::Boolean(v) => self.visit_boolean(v),
+            ExpressionKind::Integer(v) => self.visit_integer(v),
+            ExpressionKind::Float(v) => self.visit_float(v),
+            ExpressionKind::String(v) => self.visit_string(v),
+            ExpressionKind::Null(v) => self.visit_null(v),
+            ExpressionKind::Array(v) => self.visit_array(v),
+            ExpressionKind::Var(v) => self.visit_var(v),
+            ExpressionKind::Call(v) => self.visit_call(v),
+            ExpressionKind::Index(v) => self.visit_index(v),
+            ExpressionKind::Function(v) => self.visit_function(v),
+            ExpressionKind::Identifier(v) => self.visit_identifier(v),
+            ExpressionKind::If(v) => self.visit_if(v),
+            ExpressionKind::Infix(v) => self.visit_infix(v),
+            ExpressionKind::Prefix(v) => self.visit_prefix(v),
+            ExpressionKind::Block(v) => self.visit_block(v),
         }
     }
 

--- a/birgen/src/lib.rs
+++ b/birgen/src/lib.rs
@@ -2,9 +2,11 @@ use std::collections::HashMap;
 
 use ast::{
     Expression,
+    ExpressionKind,
     InfixExpression,
     Program,
     Statement,
+    StatementKind,
 };
 use lexer::{
     AssignmentKind,
@@ -135,11 +137,11 @@ impl<'sess> BIRGen<'sess> {
     }
 
     pub fn generate_statement<'ast>(&mut self, stmt: &Statement<'ast>) {
-        match stmt {
-            Statement::Expression(expr_stmt) => {
+        match &stmt.kind {
+            StatementKind::Expression(expr_stmt) => {
                 self.generate_expression(&expr_stmt.expression);
             },
-            Statement::Return(s) => {
+            StatementKind::Return(s) => {
                 if let Some(ref return_value) = s.return_value {
                     let expr = self.generate_expression(&return_value);
                     self.inner.pin_mut().build_return(&expr);
@@ -147,7 +149,7 @@ impl<'sess> BIRGen<'sess> {
                     self.inner.pin_mut().build_empty_return();
                 }
             },
-            Statement::While(while_stmt) => {
+            StatementKind::While(while_stmt) => {
                 let mut guard = self.bir_codegen.pin_mut().build_while_op();
 
                 guard.pin_mut().enter_cond();
@@ -164,7 +166,7 @@ impl<'sess> BIRGen<'sess> {
                 drop(bg);
                 self.inner.pin_mut().build_empty_yield();
             },
-            Statement::VarDecl(var) => {
+            StatementKind::VarDecl(var) => {
                 let value = &var.value;
 
                 let Some(value) = value else {
@@ -181,56 +183,56 @@ impl<'sess> BIRGen<'sess> {
                     return;
                 };
 
-                match **value {
-                    Expression::Integer(ref i) => {
+                match &value.kind {
+                    ExpressionKind::Integer(i) => {
                         let v = self.inner.pin_mut().build_constant_int(i.value);
                         let name = self.session.lookup_string(var.name.value);
                         let declare = self.inner.pin_mut().build_var_declare(&v, name);
                         self.inner.pin_mut().build_var_store(&v, &declare);
                         self.symbol_table.insert(var.name.value, declare);
                     },
-                    Expression::Float(ref f) => {
+                    ExpressionKind::Float(f) => {
                         let v = self.inner.pin_mut().build_constant_float(f.value);
                         let name = self.session.lookup_string(var.name.value);
                         let declare = self.inner.pin_mut().build_var_declare(&v, name);
                         self.inner.pin_mut().build_var_store(&v, &declare);
                         self.symbol_table.insert(var.name.value, declare);
                     },
-                    Expression::Identifier(_)
-                    | Expression::Infix(_)
-                    | Expression::String(_)
-                    | Expression::Function(_)
-                    | Expression::Call(_) => {
+                    ExpressionKind::Identifier(_)
+                    | ExpressionKind::Infix(_)
+                    | ExpressionKind::String(_)
+                    | ExpressionKind::Function(_)
+                    | ExpressionKind::Call(_) => {
                         let v = self.generate_expression(&value);
                         let name = self.session.lookup_string(var.name.value);
                         let declare = self.inner.pin_mut().build_var_declare(&v, name);
                         self.inner.pin_mut().build_var_store(&v, &declare);
                         self.symbol_table.insert(var.name.value, declare);
                     },
-                    _ => todo!("Generation for expression {:?} not implemented", **value),
+                    _ => todo!("Generation for expression {:?} not implemented", value.kind),
                 }
             },
-            Statement::StructDecl(s) => {
+            StatementKind::StructDecl(_s) => {
                 // TODO: Implement struct declaration
             },
-            Statement::Break(_s) => {
+            StatementKind::Break(_s) => {
                 self.bir_codegen.pin_mut().build_break_op();
             },
-            Statement::Continue(_s) => {
+            StatementKind::Continue(_s) => {
                 self.inner.pin_mut().build_continue();
             },
         }
     }
 
     pub fn generate_expression<'ast>(&mut self, expr: &Expression<'ast>) -> cxx::UniquePtr<ffi::BIRValue> {
-        match expr {
-            Expression::Integer(lit) => self.inner.pin_mut().build_constant_int(lit.value),
-            Expression::Float(lit) => self.inner.pin_mut().build_constant_float(lit.value),
-            Expression::Boolean(lit) => self.inner.pin_mut().build_constant_bool(lit.value),
-            Expression::Infix(infix) => self.generate_infix(infix),
-            Expression::Call(call) => {
+        match &expr.kind {
+            ExpressionKind::Integer(lit) => self.inner.pin_mut().build_constant_int(lit.value),
+            ExpressionKind::Float(lit) => self.inner.pin_mut().build_constant_float(lit.value),
+            ExpressionKind::Boolean(lit) => self.inner.pin_mut().build_constant_bool(lit.value),
+            ExpressionKind::Infix(infix) => self.generate_infix(infix),
+            ExpressionKind::Call(call) => {
                 // HACK: this checks for the print function hardcoded-ly
-                if let Expression::Identifier(ref ident) = *call.function
+                if let ExpressionKind::Identifier(ref ident) = call.function.kind
                     && ident.value == syms::PRINT
                 {
                     // TODO: handle more than one arguments
@@ -249,7 +251,7 @@ impl<'sess> BIRGen<'sess> {
                 }
                 self.inner.pin_mut().finish_call()
             },
-            Expression::Var(var) => {
+            ExpressionKind::Var(var) => {
                 let name_sym = var.name.value;
                 let val = self.generate_expression(var.value);
                 let ssa = self.symbol_table.get(&name_sym).expect("Variable not declared");
@@ -279,18 +281,18 @@ impl<'sess> BIRGen<'sess> {
                     _ => todo!("Assignment kind {:?} not supported", var.kind),
                 }
             },
-            Expression::Identifier(ident) => {
+            ExpressionKind::Identifier(ident) => {
                 if let Some(ssa) = self.symbol_table.get(&ident.value) {
                     self.inner.pin_mut().build_var_load(ssa)
                 } else {
                     cxx::UniquePtr::null() // FIXME: don't return nullptr
                 }
             },
-            Expression::String(s) => {
+            ExpressionKind::String(s) => {
                 let v = self.session.lookup_string(s.value);
                 self.inner.pin_mut().build_constant_string(v)
             },
-            Expression::Function(func) => {
+            ExpressionKind::Function(func) => {
                 let result = match func.explicit_ty.unwrap() {
                     syms::STRING => ffi::TypeKind::String,
                     syms::INT => ffi::TypeKind::Int,
@@ -335,7 +337,7 @@ impl<'sess> BIRGen<'sess> {
 
                 guard.get_value()
             },
-            Expression::If(if_expr) => {
+            ExpressionKind::If(if_expr) => {
                 let cond = self.generate_expression(if_expr.condition);
                 let mut guard = self.inner.pin_mut().build_if_expr(&cond);
 
@@ -347,8 +349,8 @@ impl<'sess> BIRGen<'sess> {
 
                 if let Some(alt) = if_expr.alternative {
                     guard.pin_mut().start_else();
-                    match alt {
-                        Expression::Block(block) => {
+                    match &alt.kind {
+                        ExpressionKind::Block(block) => {
                             for stmt in block.statements {
                                 self.generate_statement(stmt);
                             }
@@ -361,7 +363,7 @@ impl<'sess> BIRGen<'sess> {
 
                 guard.get_value()
             },
-            Expression::Block(blk) => {
+            ExpressionKind::Block(blk) => {
                 let mut guard = self.inner.pin_mut().build_block_expr();
                 guard.pin_mut().start_body();
 
@@ -373,7 +375,7 @@ impl<'sess> BIRGen<'sess> {
                 self.inner.pin_mut().build_empty_yield();
                 cxx::UniquePtr::null()
             },
-            _ => todo!("Generation for expression {:?} not implemented", expr),
+            _ => todo!("Generation for expression {:?} not implemented", expr.kind),
         }
     }
 

--- a/tests/AST/struct-invalid-stmt.bel
+++ b/tests/AST/struct-invalid-stmt.bel
@@ -5,7 +5,7 @@ struct A {
 }
 
 # CHECK:      error: error parsing struct
-# CHECK-NEXT:  --> {{.*}}/tests/AST/struct-invalid-stmt.bel:4:10
+# CHECK-NEXT:  --> {{.*}}/tests/AST/struct-invalid-stmt.bel:4:3
 # CHECK-NEXT:   |
 # CHECK-NEXT: 4 |   return 1
-# CHECK-NEXT:   |          ^ invalid statement
+# CHECK-NEXT:   |   ^^^^^^^^ invalid statement

--- a/ty/src/lib.rs
+++ b/ty/src/lib.rs
@@ -97,6 +97,7 @@ fn sym_to_ty(symbol: Symbol) -> Type {
 mod tests {
     use ast::{
         Expression,
+        ExpressionKind,
         Identifier,
         IntegerLiteral,
         StringLiteral,
@@ -115,7 +116,10 @@ mod tests {
 
     #[test]
     fn test_implicit_string() {
-        let str_expr = Expression::String(StringLiteral { value: Symbol(1) });
+        let str_expr = Expression {
+            kind: ExpressionKind::String(StringLiteral { value: Symbol(1) }),
+            span: Default::default(),
+        };
         let expr = VarDeclStatement {
             name: Identifier { value: Symbol(0) },
             explicit_ty: None,
@@ -131,7 +135,10 @@ mod tests {
 
     #[test]
     fn test_explicit_int() {
-        let int_expr = Expression::Integer(IntegerLiteral { value: 12 });
+        let int_expr = Expression {
+            kind: ExpressionKind::Integer(IntegerLiteral { value: 12 }),
+            span: Default::default(),
+        };
         let expr = VarDeclStatement {
             name: Identifier { value: Symbol(0) },
             explicit_ty: Some(syms::INT),


### PR DESCRIPTION
The AST nodes didn't have a span field. This PR changes the existing `Expression` enum into a `ExpressionKind` enum and makes another `Expression` struct that has a span field. This mimics the `Token` implementation which also has this distinction.

Closes #221 
Closes #222 