### PR TITLE
[ty] Prepare type checker implementation

### DIFF
--- a/bbuild/src/lib.rs
+++ b/bbuild/src/lib.rs
@@ -23,7 +23,7 @@ use ast::{
 use birgen::BIRGen;
 use lexer::Lexer;
 use session::Session;
-use ty::TypeInferer;
+use ty::TypeChecker;
 
 pub struct BuildContext {
     pub use_color: bool,
@@ -131,7 +131,7 @@ impl BBuild {
     }
 
     pub fn infer_types<'ast>(&self, program: &Program<'ast>) -> anyhow::Result<()> {
-        let mut ty_infer = TypeInferer::new(&self.session);
+        let mut ty_infer = TypeChecker::new(&self.session);
         ty_infer.infer(program);
         self.check_errors()?;
         Ok(())

--- a/ty/BUILD.bazel
+++ b/ty/BUILD.bazel
@@ -1,16 +1,17 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
-	name = "ty",
-	srcs = glob(["src/*.rs"]),
-	deps = [
+    name = "ty",
+    srcs = glob(["src/*.rs"]),
+    deps = [
         "//ast",
+        "//diag",
         "//session",
-	],
-	visibility = ["//visibility:public"],
+    ],
+    visibility = ["//visibility:public"],
 )
 
 rust_test(
-	name = "ty-test",
-	crate = ":ty",
+    name = "ty-test",
+    crate = ":ty",
 )

--- a/ty/src/lib.rs
+++ b/ty/src/lib.rs
@@ -17,16 +17,16 @@ pub enum Type {
     None,
 }
 
-pub struct TypeInferer<'sess> {
+pub struct TypeChecker<'sess> {
     #[allow(dead_code)]
     session: &'sess Session,
     env: HashMap<Symbol, Type>,
     current_type: Type,
 }
 
-impl<'sess> TypeInferer<'sess> {
-    pub fn new(session: &'sess Session) -> TypeInferer<'sess> {
-        TypeInferer {
+impl<'sess> TypeChecker<'sess> {
+    pub fn new(session: &'sess Session) -> TypeChecker<'sess> {
+        TypeChecker {
             session,
             env: HashMap::new(),
             current_type: Type::None,
@@ -38,7 +38,7 @@ impl<'sess> TypeInferer<'sess> {
     }
 }
 
-impl<'ast, 'sess> Visitor<'ast> for TypeInferer<'sess> {
+impl<'ast, 'sess> Visitor<'ast> for TypeChecker<'sess> {
     fn visit_integer(&mut self, _node: &ast::IntegerLiteral) {
         self.current_type = Type::Integer;
     }
@@ -102,7 +102,7 @@ mod tests {
 
     use super::{
         Type,
-        TypeInferer,
+        TypeChecker,
     };
 
     #[test]
@@ -118,7 +118,7 @@ mod tests {
         };
 
         let session = Session::for_text("".to_string()).unwrap();
-        let mut ty_infer = TypeInferer::new(&session);
+        let mut ty_infer = TypeChecker::new(&session);
         ty_infer.visit_var_decl_statement(&expr);
 
         assert_eq!(*ty_infer.env.get(&Symbol(0)).unwrap(), Type::String);
@@ -138,7 +138,7 @@ mod tests {
         };
 
         let session = Session::for_text("".to_string()).unwrap();
-        let mut ty_infer = TypeInferer::new(&session);
+        let mut ty_infer = TypeChecker::new(&session);
         ty_infer.visit_var_decl_statement(&expr);
 
         assert_eq!(*ty_infer.env.get(&Symbol(0)).unwrap(), Type::Integer);

--- a/ty/src/lib.rs
+++ b/ty/src/lib.rs
@@ -20,37 +20,25 @@ pub enum Type {
 pub struct TypeInferer<'sess> {
     #[allow(dead_code)]
     session: &'sess Session,
-    inner: TypeInfererInner,
+    env: HashMap<Symbol, Type>,
+    current_type: Type,
 }
 
 impl<'sess> TypeInferer<'sess> {
     pub fn new(session: &'sess Session) -> TypeInferer<'sess> {
         TypeInferer {
             session,
-            inner: TypeInfererInner::new(),
-        }
-    }
-
-    pub fn infer<'ast>(&mut self, program: &ast::Program<'ast>) {
-        self.inner.visit_program(program);
-    }
-}
-
-pub(crate) struct TypeInfererInner {
-    env: HashMap<Symbol, Type>,
-    current_type: Type,
-}
-
-impl TypeInfererInner {
-    pub fn new() -> Self {
-        Self {
             env: HashMap::new(),
             current_type: Type::None,
         }
     }
+
+    pub fn infer<'ast>(&mut self, program: &ast::Program<'ast>) {
+        self.visit_program(program);
+    }
 }
 
-impl<'ast> Visitor<'ast> for TypeInfererInner {
+impl<'ast, 'sess> Visitor<'ast> for TypeInferer<'sess> {
     fn visit_integer(&mut self, _node: &ast::IntegerLiteral) {
         self.current_type = Type::Integer;
     }
@@ -104,14 +92,17 @@ mod tests {
         VarDeclStatement,
         Visitor,
     };
-    use session::interner::{
-        Symbol,
-        syms,
+    use session::{
+        Session,
+        interner::{
+            Symbol,
+            syms,
+        },
     };
 
     use super::{
         Type,
-        TypeInfererInner,
+        TypeInferer,
     };
 
     #[test]
@@ -126,7 +117,8 @@ mod tests {
             value: Some(&str_expr),
         };
 
-        let mut ty_infer = TypeInfererInner::new();
+        let session = Session::for_text("".to_string()).unwrap();
+        let mut ty_infer = TypeInferer::new(&session);
         ty_infer.visit_var_decl_statement(&expr);
 
         assert_eq!(*ty_infer.env.get(&Symbol(0)).unwrap(), Type::String);
@@ -145,7 +137,8 @@ mod tests {
             value: Some(&int_expr),
         };
 
-        let mut ty_infer = TypeInfererInner::new();
+        let session = Session::for_text("".to_string()).unwrap();
+        let mut ty_infer = TypeInferer::new(&session);
         ty_infer.visit_var_decl_statement(&expr);
 
         assert_eq!(*ty_infer.env.get(&Symbol(0)).unwrap(), Type::Integer);


### PR DESCRIPTION
Previous version of TypeChecker (nee TypeInferer) was split into two: TypeInferer and TypeChecker. This was originally done to ease unit tests. However, the split won't be significant as the inner will have to get access to session in order to emit diagnostics. Therefore, the two is merged.

The name change is because I believe the term TypeChecker is more appropriate to use than TypeInferer. Its main job is to check types rather than infer types. While it could be argued, I like the name TypeChecker better.