### PR TITLE
[bir] Implement struct type and its LLVM lowering

### DIFF
--- a/bir/BUILD.bazel
+++ b/bir/BUILD.bazel
@@ -151,6 +151,7 @@ cc_library(
         "lib/IR/BIRAttrs.cpp",
         "lib/IR/BIRDialect.cpp",
         "lib/IR/BIROps.cpp",
+        "lib/IR/BIRTypes.cpp",
         "lib/Pipelines.cpp",
         "lib/Interfaces/LoopOpInterface.cpp",
         "lib/Transforms/LowerPrintToRuntime.cpp",

--- a/bir/include/belalang/BIR/IR/BIRTypes.td
+++ b/bir/include/belalang/BIR/IR/BIRTypes.td
@@ -25,6 +25,17 @@ def BIR_BoolType : BIR_Type<"Bool", "bool"> {
   let summary = "Boolean type";
 }
 
+def BIR_StructType : BIR_Type<"Struct", "struct"> {
+  let summary = "Struct type";
+
+  let parameters = (ins
+    ArrayRefParameter<"mlir::Type", "struct members">:$members,
+    "mlir::StringAttr":$name
+  );
+
+  let hasCustomAssemblyFormat = 1;
+}
+
 def BIR_RefType : BIR_Type<"Ref", "ref"> {
   let summary = "Reference type";
 

--- a/bir/lib/IR/BIRDialect.cpp
+++ b/bir/lib/IR/BIRDialect.cpp
@@ -11,6 +11,23 @@
 #include "belalang/BIR/IR/BIRDialect.cpp.inc"
 #include "belalang/BIR/IR/BIREnumAttrs.cpp.inc"
 
+namespace {
+using namespace belalang;
+
+struct BIROpAsmDialectInterface : public OpAsmDialectInterface {
+  using OpAsmDialectInterface::OpAsmDialectInterface;
+
+  AliasResult getAlias(Type type, raw_ostream &os) const override {
+    if (auto structType = dyn_cast<bir::StructType>(type)) {
+      auto nameAttr = structType.getName();
+      os << "struct_" << nameAttr.getValue();
+      return AliasResult::OverridableAlias;
+    }
+    return AliasResult::NoAlias;
+  }
+};
+} // namespace
+
 namespace belalang {
 namespace bir {
 
@@ -29,6 +46,8 @@ void BIRDialect::initialize() {
 #define GET_ATTRDEF_LIST
 #include "belalang/BIR/IR/BIRAttrs.cpp.inc"
       >();
+
+  addInterface<BIROpAsmDialectInterface>();
 }
 
 } // namespace bir

--- a/bir/lib/IR/BIRTypes.cpp
+++ b/bir/lib/IR/BIRTypes.cpp
@@ -1,0 +1,46 @@
+#include "belalang/BIR/IR/BIR.h"
+
+namespace belalang {
+namespace bir {
+
+mlir::Type StructType::parse(mlir::AsmParser &p) {
+  mlir::MLIRContext *ctx = p.getContext();
+  std::string name;
+  llvm::SmallVector<mlir::Type> members;
+
+  // `<`
+  if (p.parseLess().failed())
+    return {};
+
+  // `<structname>`
+  if (p.parseString(&name).failed())
+    return {};
+
+  // `,`
+  if (p.parseComma().failed())
+    return {};
+
+  // `{<member1>, <member2>, ..., <membern>}`
+  if (p.parseCommaSeparatedList(AsmParser::Delimiter::Braces, [&p, &members]() {
+         return p.parseType(members.emplace_back());
+       }).failed())
+    return {};
+
+  // `>`
+  if (p.parseGreater().failed())
+    return {};
+
+  auto nameAttr = mlir::StringAttr::get(ctx, name);
+  return StructType::get(ctx, members, nameAttr);
+}
+
+void StructType::print(mlir::AsmPrinter &p) const {
+  p << '<';
+  p.printString(getName());
+  p << ", {";
+  llvm::interleaveComma(getMembers(), p);
+  p << "}>";
+}
+
+} // namespace bir
+} // namespace belalang

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -605,6 +605,14 @@ struct BIRToLLVMTypeConverter : public mlir::LLVMTypeConverter {
       mlir::Type iType = mlir::IntegerType::get(ctx, 64);
       return LLVM::LLVMStructType::getLiteral(ctx, {ptrType, iType});
     });
+    addConversion([this, ctx](bir::StructType ty) {
+      llvm::SmallVector<mlir::Type> llvmMembers;
+      for (auto m : ty.getMembers())
+        llvmMembers.push_back(convertType(m));
+      auto llvmStruct = LLVM::LLVMStructType::getIdentified(ctx, ty.getName());
+      assert(llvmStruct.setBody(llvmMembers, false).succeeded());
+      return llvmStruct;
+    });
     addConversion([](bir::RefType ty) {
       return LLVM::LLVMPointerType::get(ty.getContext());
     });

--- a/tests/BIR/IR/struct-type.mlir
+++ b/tests/BIR/IR/struct-type.mlir
@@ -1,0 +1,15 @@
+// RUN: %bir-opt --split-input-file --verify-roundtrip --verify-diagnostics %s | %FileCheck %s
+
+// CHECK: !struct_T = !bir.struct<"T", {!bir.int, !bir.int}>
+// CHECK: bir.func @f(%{{.*}}: !struct_T)
+bir.func @f(%0: !bir.struct<"T", {!bir.int, !bir.int}>) {
+  bir.return
+}
+
+// -----
+
+// CHECK: !struct_T = !bir.struct<"T", {}>
+// CHECK: bir.func @f(%{{.*}}: !struct_T)
+bir.func @f(%0: !bir.struct<"T", {}>) {
+  bir.return
+}

--- a/tests/BIR/Transforms/BIRToLLVM/struct-type.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/struct-type.mlir
@@ -1,0 +1,13 @@
+// RUN: %bir-opt --split-input-file --convert-bir-to-llvm %s | %FileCheck %s
+
+// CHECK: llvm.func @f(%arg0: !llvm.struct<"T", (i64, i64)>)
+bir.func @f(%0: !bir.struct<"T", {!bir.int, !bir.int}>) {
+  bir.return
+}
+
+// -----
+
+// CHECK: llvm.func @f(%arg0: !llvm.struct<"T", ()>)
+bir.func @f(%0: !bir.struct<"T", {}>) {
+  bir.return
+}


### PR DESCRIPTION
BIR's struct type design is similar to CIR's. The major difference is that we don't have `RecordType`. In CIR, `RecordType` is used for both C/C++ `struct` and `union`. Belalang currently only has `struct`. Therefore, BIR's struct implementation directly uses `bir.struct` and not via `bir.record`.

Part of #219 