### PR TITLE
[bir] Implement GetMemberOp and its lowering to GEP

### DIFF
--- a/bir/include/belalang/BIR/IR/BIROps.td
+++ b/bir/include/belalang/BIR/IR/BIROps.td
@@ -538,4 +538,23 @@ def BIR_CmpOp : BIR_Op<"cmp", [
   let hasBIRGenBindings = false; // TODO: make bindings
 }
 
+def BIR_GetMemberOp : BIR_Op<"get_member"> {
+  let arguments = (ins
+    BIR_RefType:$addr, // TODO: maybe make a pointer type?
+    StrAttr:$name,
+    IndexAttr:$index_attr
+  );
+
+  let results = (outs
+    BIR_RefType:$result
+  );
+
+  let assemblyFormat = [{
+    $addr `[` $index_attr `]` attr-dict
+    `:` type($addr) `->` type($result)
+  }];
+
+  let hasBIRGenBindings = false; // TODO: make bindings
+}
+
 #endif // BELALANG_IR_OPS_TD_

--- a/bir/include/belalang/BIR/IR/BIRTypes.td
+++ b/bir/include/belalang/BIR/IR/BIRTypes.td
@@ -39,7 +39,7 @@ def BIR_StructType : BIR_Type<"Struct", "struct"> {
 def BIR_RefType : BIR_Type<"Ref", "ref"> {
   let summary = "Reference type";
 
-  let parameters = (ins AnyTypeOf<[BIR_IntType, BIR_FloatType, BIR_StringType, FunctionType, BIR_BoolType]>:$el);
+  let parameters = (ins AnyTypeOf<[BIR_IntType, BIR_FloatType, BIR_StringType, FunctionType, BIR_BoolType, BIR_StructType]>:$el);
 
   let assemblyFormat = "`<` $el `>`";
 }

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -587,6 +587,27 @@ struct CmpOpLowering final : public OpConversionPattern<bir::CmpOp> {
   }
 };
 
+struct GetMemberOpLowering final : public OpConversionPattern<bir::GetMemberOp> {
+  using OpConversionPattern<bir::GetMemberOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(bir::GetMemberOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    mlir::Type llvmResTy = getTypeConverter()->convertType(op.getType());
+    mlir::Type pointee = op.getAddr().getType().getEl();
+
+    auto structTy = mlir::cast<bir::StructType>(pointee);
+    llvm::SmallVector<mlir::LLVM::GEPArg, 2> offset{0, op.getIndexAttr().getZExtValue()};
+    const mlir::Type elementTy = getTypeConverter()->convertType(structTy);
+    mlir::LLVM::GEPNoWrapFlags flags = 
+        mlir::LLVM::GEPNoWrapFlags::inbounds | mlir::LLVM::GEPNoWrapFlags::nuw;
+    rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
+        op, llvmResTy, elementTy, adaptor.getAddr(), offset, flags);
+
+    return success();
+  }
+};
+
 struct BIRToLLVMTypeConverter : public mlir::LLVMTypeConverter {
   BIRToLLVMTypeConverter(mlir::MLIRContext *ctx)
       : mlir::LLVMTypeConverter(ctx) {
@@ -631,7 +652,8 @@ void belalang::bir::populateBelalangBIRToLLVMPatterns(
                SubOpLowering, MulOpLowering, DivOpLowering, ModOpLowering,
                AndOpLowering, OrOpLowering, XorOpLowering, ShlOpLowering,
                ShrOpLowering, VarDeclareOpLowering, VarStoreOpLowering,
-               VarLoadOpLowering, CondBrLowering, CmpOpLowering>(
+               VarLoadOpLowering, CondBrLowering, CmpOpLowering,
+               GetMemberOpLowering>(
       typeConverter, patterns.getContext());
 }
 

--- a/tests/BIR/IR/get-member-op.mlir
+++ b/tests/BIR/IR/get-member-op.mlir
@@ -1,0 +1,9 @@
+// RUN: %bir-opt --split-input-file --verify-roundtrip --verify-diagnostics %s | %FileCheck %s
+
+// CHECK: bir.func @f(%[[ARG0:.*]]: !bir.ref<!struct_T>)
+bir.func @f(%0: !bir.ref<!bir.struct<"T", {!bir.int}>>) {
+  // CHECK: bir.get_member %[[ARG0]][0] {name = "x"} : <!struct_T> -> <!bir.int>
+  bir.get_member %0[0] { name = "x" }
+      : !bir.ref<!bir.struct<"T", {!bir.int}>> -> !bir.ref<!bir.int>
+  bir.return
+}

--- a/tests/BIR/Transforms/BIRToLLVM/get-member-op.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/get-member-op.mlir
@@ -1,0 +1,8 @@
+// RUN: %bir-opt --split-input-file --convert-bir-to-llvm %s | %FileCheck %s
+
+bir.func @f(%0: !bir.ref<!bir.struct<"T", {!bir.int}>>) {
+  // CHECK: llvm.getelementptr inbounds|nuw %{{.*}}[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"T", (i64)>
+  bir.get_member %0[0] { name = "x" }
+      : !bir.ref<!bir.struct<"T", {!bir.int}>> -> !bir.ref<!bir.int>
+  bir.return
+}


### PR DESCRIPTION
BIR's GetMemberOp is similar to CIR's. However, CIR has another op called ExtractMemberOp. As of now, Belalang is not mature enough to differentiate between the two. Therefore, only GetMemberOp is implemented in this change. Moreover, its LLVM lowering is to the `getelementptr` op in LLVM.

Part of #219 