### PR TITLE
[lexer][ast] Parse member access expression

### DIFF
--- a/ast/src/dump.rs
+++ b/ast/src/dump.rs
@@ -13,6 +13,7 @@ use super::{
     IndexExpression,
     InfixExpression,
     IntegerLiteral,
+    MemberAccessExpression,
     NullLiteral,
     PrefixExpression,
     Program,
@@ -156,6 +157,13 @@ impl<'ast> Visitor<'ast> for ASTDumper<'_> {
         println!("{:indent$}IndexExpression", "", indent = self.indent);
         self.indent += 2;
         self.walk_index(node);
+        self.indent -= 2;
+    }
+
+    fn visit_member_access(&mut self, node: &MemberAccessExpression<'ast>) {
+        println!("{:indent$}MemberAccessExpression", "", indent = self.indent);
+        self.indent += 2;
+        self.walk_member_access(node);
         self.indent -= 2;
     }
 

--- a/ast/src/expressions.rs
+++ b/ast/src/expressions.rs
@@ -207,6 +207,13 @@ pub struct BlockExpression<'ast> {
     pub statements: &'ast [Statement<'ast>],
 }
 
+/// Represents an access to member
+#[derive(Debug, Clone, Copy)]
+pub struct MemberAccessExpression<'ast> {
+    pub source: &'ast Expression<'ast>,
+    pub member: Identifier,
+}
+
 /// Represents all expressions supported by The Belalang Compiler.
 #[derive(Debug, Clone, Copy)]
 pub struct Expression<'ast> {
@@ -231,4 +238,5 @@ pub enum ExpressionKind<'ast> {
     Infix(InfixExpression<'ast>),
     Prefix(PrefixExpression<'ast>),
     Block(BlockExpression<'ast>),
+    MemberAccess(MemberAccessExpression<'ast>),
 }

--- a/ast/src/parser.rs
+++ b/ast/src/parser.rs
@@ -37,6 +37,7 @@ use crate::{
     IndexExpression,
     InfixExpression,
     IntegerLiteral,
+    MemberAccessExpression,
     PrefixExpression,
     Program,
     ReturnStatement,
@@ -81,7 +82,7 @@ impl From<&TokenKind> for Precedence {
             TokenKind::Add | TokenKind::Sub => Self::Additive,
             TokenKind::Div | TokenKind::Mul | TokenKind::Mod => Self::Multiplicative,
             TokenKind::LeftParen => Self::Call,
-            TokenKind::LeftBracket => Self::Index,
+            TokenKind::LeftBracket | TokenKind::Dot => Self::Index,
             _ => Self::Lowest,
         }
     }
@@ -520,6 +521,26 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
                 Ok(Some(self.ast.alloc(Expression {
                     kind: ExpressionKind::Index(IndexExpression { left, index }),
+                    span,
+                })))
+            },
+
+            // matches `.`
+            TokenKind::Dot => {
+                self.next_token()?; // curr_token is now `.`
+                self.next_token()?; // curr_token is not the property expr
+
+                // expect the property identifier
+                let TokenKind::Ident { sym } = self.curr_token.kind else {
+                    return Err(self.error_unexpected_token());
+                };
+
+                let member = Identifier { value: sym };
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
+
+                // make member access!
+                Ok(Some(self.ast.alloc(Expression {
+                    kind: ExpressionKind::MemberAccess(MemberAccessExpression { source: left, member }),
                     span,
                 })))
             },

--- a/ast/src/visitor.rs
+++ b/ast/src/visitor.rs
@@ -15,6 +15,7 @@ use super::{
     IndexExpression,
     InfixExpression,
     IntegerLiteral,
+    MemberAccessExpression,
     NullLiteral,
     PrefixExpression,
     Program,
@@ -67,6 +68,10 @@ pub trait Visitor<'ast> {
 
     fn visit_index(&mut self, node: &IndexExpression<'ast>) {
         self.walk_index(node);
+    }
+
+    fn visit_member_access(&mut self, node: &MemberAccessExpression<'ast>) {
+        self.walk_member_access(node);
     }
 
     fn visit_function(&mut self, node: &FunctionLiteral<'ast>) {
@@ -148,6 +153,7 @@ pub trait Visitor<'ast> {
             ExpressionKind::Infix(v) => self.visit_infix(v),
             ExpressionKind::Prefix(v) => self.visit_prefix(v),
             ExpressionKind::Block(v) => self.visit_block(v),
+            ExpressionKind::MemberAccess(v) => self.visit_member_access(v),
         }
     }
 
@@ -172,6 +178,11 @@ pub trait Visitor<'ast> {
     fn walk_index(&mut self, node: &IndexExpression<'ast>) {
         self.visit_expression(node.left);
         self.visit_expression(node.index);
+    }
+
+    fn walk_member_access(&mut self, node: &MemberAccessExpression<'ast>) {
+        self.visit_expression(node.source);
+        self.visit_identifier(&node.member);
     }
 
     fn walk_function(&mut self, node: &FunctionLiteral<'ast>) {

--- a/lexer/src/lexer.rs
+++ b/lexer/src/lexer.rs
@@ -431,6 +431,13 @@ impl<'sess> Lexer<'sess> {
                     kind: TokenKind::Comma,
                 })
             },
+            Some('.') => {
+                self.advance();
+                Ok(Token {
+                    span: SourceSpan::default(),
+                    kind: TokenKind::Dot,
+                })
+            },
             Some('\\') => {
                 self.advance();
                 Ok(Token {

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -115,6 +115,9 @@ pub enum TokenKind {
     /// Struct keyword `struct`
     Struct,
 
+    /// Dot operator `.`
+    Dot,
+
     /// Comma separator `,`
     Comma,
     /// Semicolon terminator `;`

--- a/tests/AST/member-access-expression.bel
+++ b/tests/AST/member-access-expression.bel
@@ -1,0 +1,9 @@
+# RUN: %belalang build --emit ast %s | %FileCheck %s
+
+some_struct.member
+
+# CHECK:      Program
+# CHECK-NEXT:   ExpressionStatement
+# CHECK-NEXT:     MemberAccessExpression
+# CHECK-NEXT:       Identifier(some_struct)
+# CHECK-NEXT:       Identifier(member)

--- a/tests/Tokens/token-dot.bel
+++ b/tests/Tokens/token-dot.bel
@@ -1,0 +1,6 @@
+some_struct.member
+
+# RUN: %belalang build --emit=tokens %s | %FileCheck %s
+# CHECK: Ident("some_struct") <0..11>
+# CHECK: Dot <11..12>
+# CHECK: Ident("member") <12..18>


### PR DESCRIPTION
This change implements the frontend for parsing member access expressions.

Part of #219 