### PR TITLE
[bir] Use qualified format for ref types

### DIFF
--- a/bir/include/belalang/BIR/IR/BIROps.td
+++ b/bir/include/belalang/BIR/IR/BIROps.td
@@ -355,7 +355,7 @@ def BIR_VarDeclareOp : BIR_Op<"var.declare"> {
   let arguments = (ins StrAttr:$name);
   let results = (outs BIR_RefType:$result);
 
-  let assemblyFormat = "$name attr-dict `:` type($result)";
+  let assemblyFormat = "$name attr-dict `:` qualified(type($result))";
   let hasBIRGenBindings = false; // TODO: make bindings
 }
 
@@ -364,7 +364,7 @@ def BIR_VarStoreOp : BIR_Op<"var.store"> {
 
   let arguments = (ins BIR_AnyType:$src, BIR_RefType:$dest);
 
-  let assemblyFormat = "$src `to` $dest attr-dict `:` type($src) `to` type($dest)";
+  let assemblyFormat = "$src `to` $dest attr-dict `:` type($src) `to` qualified(type($dest))";
   let hasBIRGenBindings = false; // TODO: make bindings
 }
 
@@ -551,7 +551,7 @@ def BIR_GetMemberOp : BIR_Op<"get_member"> {
 
   let assemblyFormat = [{
     $addr `[` $index_attr `]` attr-dict
-    `:` type($addr) `->` type($result)
+    `:` qualified(type($addr)) `->` qualified(type($result))
   }];
 
   let hasBIRGenBindings = false; // TODO: make bindings

--- a/tests/BIR/IR/get-member-op.mlir
+++ b/tests/BIR/IR/get-member-op.mlir
@@ -2,7 +2,7 @@
 
 // CHECK: bir.func @f(%[[ARG0:.*]]: !bir.ref<!struct_T>)
 bir.func @f(%0: !bir.ref<!bir.struct<"T", {!bir.int}>>) {
-  // CHECK: bir.get_member %[[ARG0]][0] {name = "x"} : <!struct_T> -> <!bir.int>
+  // CHECK: bir.get_member %[[ARG0]][0] {name = "x"} : !bir.ref<!struct_T> -> !bir.ref<!bir.int>
   bir.get_member %0[0] { name = "x" }
       : !bir.ref<!bir.struct<"T", {!bir.int}>> -> !bir.ref<!bir.int>
   bir.return

--- a/tests/BIRGen/block_yield.bel
+++ b/tests/BIRGen/block_yield.bel
@@ -13,5 +13,5 @@ x: Int = {
 # CHECK-NEXT:   %[[C3:.*]] = bir.constant #bir.int<42> : !bir.int
 # CHECK-NEXT:   cf.br ^bb2(%[[C3]] : !bir.int)
 # CHECK-NEXT: ^bb2(%[[VAL:.*]]: !bir.int):  // pred: ^bb1
-# CHECK-NEXT:   %[[VAR:.*]] = bir.var.declare "x" : <!bir.int>
-# CHECK-NEXT:   bir.var.store %[[VAL]] to %[[VAR]] : !bir.int to <!bir.int>
+# CHECK-NEXT:   %[[VAR:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:   bir.var.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>

--- a/tests/BIRGen/functions.bel
+++ b/tests/BIRGen/functions.bel
@@ -4,10 +4,10 @@
 # CHECK-NEXT:   bir.func private @brt_print_int(!bir.int)
 # CHECK-NEXT:   bir.func @brt_init()
 # CHECK-NEXT:   bir.func @fn.main.anon(%[[ARG0:.*]]: !bir.int, %[[ARG1:.*]]: !bir.int) -> !bir.int {
-# CHECK-NEXT:     %[[V0:.*]] = bir.var.declare "x" : <!bir.int>
-# CHECK-NEXT:     bir.var.store %[[ARG0]] to %[[V0]] : !bir.int to <!bir.int>
-# CHECK-NEXT:     %[[V1:.*]] = bir.var.declare "y" : <!bir.int>
-# CHECK-NEXT:     bir.var.store %[[ARG1]] to %[[V1]] : !bir.int to <!bir.int>
+# CHECK-NEXT:     %[[V0:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:     bir.var.store %[[ARG0]] to %[[V0]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[V1:.*]] = bir.var.declare "y" : !bir.ref<!bir.int>
+# CHECK-NEXT:     bir.var.store %[[ARG1]] to %[[V1]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     %[[V2:.*]] = bir.var.load %[[V0]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     %[[V3:.*]] = bir.var.load %[[V1]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     %[[V4:.*]] = bir.add %[[V2]], %[[V3]] : (!bir.int, !bir.int) -> !bir.int
@@ -16,14 +16,14 @@
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
 # CHECK-NEXT:     %[[C0:.*]] = bir.constant #bir.fn<@fn.main.anon> : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     %[[V5:.*]] = bir.var.declare "add" : <(!bir.int, !bir.int) -> !bir.int>
-# CHECK-NEXT:     bir.var.store %[[C0]] to %[[V5]] : (!bir.int, !bir.int) -> !bir.int to <(!bir.int, !bir.int) -> !bir.int>
+# CHECK-NEXT:     %[[V5:.*]] = bir.var.declare "add" : !bir.ref<(!bir.int, !bir.int) -> !bir.int>
+# CHECK-NEXT:     bir.var.store %[[C0]] to %[[V5]] : (!bir.int, !bir.int) -> !bir.int to !bir.ref<(!bir.int, !bir.int) -> !bir.int>
 # CHECK-NEXT:     %[[V6:.*]] = bir.var.load %[[V5]] : (!bir.ref<(!bir.int, !bir.int) -> !bir.int>) -> ((!bir.int, !bir.int) -> !bir.int)
 # CHECK-NEXT:     %[[C1:.*]] = bir.constant #bir.int<2> : !bir.int
 # CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<3> : !bir.int
 # CHECK-NEXT:     %[[C3:.*]] = bir.call_indirect %[[V6]](%[[C1]], %[[C2]]) : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     %[[V7:.*]] = bir.var.declare "p" : <!bir.int>
-# CHECK-NEXT:     bir.var.store %[[C3]] to %[[V7]] : !bir.int to <!bir.int>
+# CHECK-NEXT:     %[[V7:.*]] = bir.var.declare "p" : !bir.ref<!bir.int>
+# CHECK-NEXT:     bir.var.store %[[C3]] to %[[V7]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     %[[V8:.*]] = bir.var.load %[[V7]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     bir.call @brt_print_int(%[[V8]]) : (!bir.int) -> ()
 # CHECK-NEXT:     %[[C4:.*]] = bir.constant #bir.int<0> : !bir.int

--- a/tests/BIRGen/if_yield.bel
+++ b/tests/BIRGen/if_yield.bel
@@ -15,5 +15,5 @@ x: Int = if true {
 # CHECK-NEXT:   %[[C3:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:   cf.br ^bb3(%[[C3]] : !bir.int)
 # CHECK-NEXT: ^bb3(%[[VAL:.*]]: !bir.int):  // 2 preds: ^bb1, ^bb2
-# CHECK-NEXT:   %[[VAR:.*]] = bir.var.declare "x" : <!bir.int>
-# CHECK-NEXT:   bir.var.store %[[VAL]] to %[[VAR]] : !bir.int to <!bir.int>
+# CHECK-NEXT:   %[[VAR:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:   bir.var.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>

--- a/tests/BIRGen/string.bel
+++ b/tests/BIRGen/string.bel
@@ -5,8 +5,8 @@
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
 # CHECK-NEXT:     %0 = bir.constant #bir.string<"hello"> : !bir.string
-# CHECK-NEXT:     %1 = bir.var.declare "x" : <!bir.string>
-# CHECK-NEXT:     bir.var.store %0 to %1 : !bir.string to <!bir.string>
+# CHECK-NEXT:     %1 = bir.var.declare "x" : !bir.ref<!bir.string>
+# CHECK-NEXT:     bir.var.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
 # CHECK-NEXT:     %2 = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %2 : !bir.int
 # CHECK-NEXT:   }

--- a/tests/BIRGen/variable_declaration.bel
+++ b/tests/BIRGen/variable_declaration.bel
@@ -7,8 +7,8 @@ y: String
 # CHECK-NEXT:   bir.func @brt_init()
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
-# CHECK-NEXT:     %[[C0:.*]] = bir.var.declare "x" : <!bir.int>
-# CHECK-NEXT:     %[[C1:.*]] = bir.var.declare "y" : <!bir.string>
+# CHECK-NEXT:     %[[C0:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[C1:.*]] = bir.var.declare "y" : !bir.ref<!bir.string>
 # CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C2]] : !bir.int
 # CHECK-NEXT:   }

--- a/tests/BIRGen/variables.bel
+++ b/tests/BIRGen/variables.bel
@@ -7,21 +7,21 @@
 # CHECK-NEXT:   bir.call @brt_init() : () -> ()
 
 # CHECK-NEXT: %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT: %[[C1:.*]] = bir.var.declare "x" : <!bir.int>
-# CHECK-NEXT: bir.var.store %[[C0]] to %[[C1]] : !bir.int to <!bir.int>
+# CHECK-NEXT: %[[C1:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT: bir.var.store %[[C0]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 
 x := 1;
 
 # CHECK-NEXT: %[[C2:.*]] = bir.constant #bir.float<1.000000e+00> : !bir.float
-# CHECK-NEXT: %[[C3:.*]] = bir.var.declare "y" : <!bir.float>
-# CHECK-NEXT: bir.var.store %[[C2]] to %[[C3]] : !bir.float to <!bir.float>
+# CHECK-NEXT: %[[C3:.*]] = bir.var.declare "y" : !bir.ref<!bir.float>
+# CHECK-NEXT: bir.var.store %[[C2]] to %[[C3]] : !bir.float to !bir.ref<!bir.float>
 y := 1.0;
 
 # CHECK-NEXT: %[[C4:.*]] = bir.var.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT: %[[C5:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C6:.*]] = bir.add %[[C4]], %[[C5]] : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT: %[[C7:.*]] = bir.var.declare "z" : <!bir.int>
-# CHECK-NEXT: bir.var.store %[[C6]] to %[[C7]] : !bir.int to <!bir.int>
+# CHECK-NEXT: %[[C7:.*]] = bir.var.declare "z" : !bir.ref<!bir.int>
+# CHECK-NEXT: bir.var.store %[[C6]] to %[[C7]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT: %[[C8:.*]] = bir.var.load %[[C7]] : (!bir.ref<!bir.int>) -> !bir.int
 z := x + 1;
 
@@ -29,13 +29,13 @@ z := x + 1;
 print(z);
 
 # CHECK-NEXT: %[[C10:.*]] = bir.constant #bir.int<10> : !bir.int
-# CHECK-NEXT: bir.var.store %[[C10]] to %[[C1]] : !bir.int to <!bir.int>
+# CHECK-NEXT: bir.var.store %[[C10]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x = 10;
 
 # CHECK-NEXT: %[[C11:.*]] = bir.constant #bir.int<5> : !bir.int
 # CHECK-NEXT: %[[C12:.*]] = bir.var.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT: %[[C13:.*]] = bir.add %[[C12]], %[[C11]] : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT: bir.var.store %[[C13]] to %[[C1]] : !bir.int to <!bir.int>
+# CHECK-NEXT: bir.var.store %[[C13]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x += 5;
 
 # CHECK-NEXT: %[[C14:.*]] = bir.constant #bir.int<0> : !bir.int

--- a/tests/BIRGen/while-loops.bel
+++ b/tests/BIRGen/while-loops.bel
@@ -5,8 +5,8 @@
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
 # CHECK-NEXT:     %[[C0:.*]] = bir.constant #bir.int<0> : !bir.int
-# CHECK-NEXT:     %[[X:.*]] = bir.var.declare "x" : <!bir.int>
-# CHECK-NEXT:     bir.var.store %[[C0]] to %[[X]] : !bir.int to <!bir.int>
+# CHECK-NEXT:     %[[X:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:     bir.var.store %[[C0]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     cf.br ^bb1
 # CHECK-NEXT:   ^bb1:  // 2 preds: ^bb0, ^bb4
 # CHECK-NEXT:     %[[L1:.*]] = bir.var.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
@@ -19,7 +19,7 @@
 # CHECK-NEXT:     %[[C1:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT:     %[[L2:.*]] = bir.var.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     %[[ADD:.*]] = bir.add %[[L2]], %[[C1]] : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     bir.var.store %[[ADD]] to %[[X]] : !bir.int to <!bir.int>
+# CHECK-NEXT:     bir.var.store %[[ADD]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     cf.br ^bb4
 # CHECK-NEXT:   ^bb4:  // pred: ^bb3
 # CHECK-NEXT:     cf.br ^bb1


### PR DESCRIPTION
Before this change, the ref types didn't use the `qualified` format directive (see https://mlir.llvm.org/docs/DefiningDialects/AttributesAndTypes/#assembly-format-directives). This results in the assembly only emitting `<!bir.thetype>` without the `bir.ref` prefix. While it still easy to tell its a referenced type, its not consistent with `bir.ref` usage. For example, those that use `functional-type` as the assembly uses qualified types for `bir.ref`.