### PR TITLE
[bir] Remove `var.` prefix on ops

### DIFF
--- a/bir/include/belalang/BIR/IR/BIROps.td
+++ b/bir/include/belalang/BIR/IR/BIROps.td
@@ -349,8 +349,8 @@ def BIR_ReturnOp : BIR_Op<"return", [
   let hasBIRGenBindings = false; // TODO: make bindings
 }
 
-def BIR_VarDeclareOp : BIR_Op<"var.declare"> {
-  let summary = "var.declare";
+def BIR_DeclareOp : BIR_Op<"declare"> {
+  let summary = "declare";
 
   let arguments = (ins StrAttr:$name);
   let results = (outs BIR_RefType:$result);
@@ -359,8 +359,8 @@ def BIR_VarDeclareOp : BIR_Op<"var.declare"> {
   let hasBIRGenBindings = false; // TODO: make bindings
 }
 
-def BIR_VarStoreOp : BIR_Op<"var.store"> {
-  let summary = "var.store";
+def BIR_StoreOp : BIR_Op<"store"> {
+  let summary = "store";
 
   let arguments = (ins BIR_AnyType:$src, BIR_RefType:$dest);
 
@@ -368,8 +368,8 @@ def BIR_VarStoreOp : BIR_Op<"var.store"> {
   let hasBIRGenBindings = false; // TODO: make bindings
 }
 
-def BIR_VarLoadOp : BIR_Op<"var.load"> {
-  let summary = "var.load";
+def BIR_VarLoadOp : BIR_Op<"load"> {
+  let summary = "load";
 
   let arguments = (ins BIR_RefType:$ref);
   let results = (outs BIR_AnyType:$result);

--- a/bir/lib/CodeGen/BIRGen.cpp
+++ b/bir/lib/CodeGen/BIRGen.cpp
@@ -143,7 +143,7 @@ std::unique_ptr<BIRValue> BIRGen::build_var_declare(const BIRValue &v,
                                                     rust::Str name) {
   auto nakedType = v.getValue().getType();
   auto refType = bir::RefType::get(&context, nakedType);
-  auto op = bir::VarDeclareOp::create(
+  auto op = bir::DeclareOp::create(
       builder, loc, refType, llvm::StringRef(name.data(), name.size()));
   return std::make_unique<BIRValue>(op.getResult());
 }
@@ -153,7 +153,7 @@ std::unique_ptr<BIRValue> BIRGen::build_var_declare_ty(TypeKind v,
   mlir::Type ty = mapType(v);
 
   auto refType = bir::RefType::get(&context, ty);
-  auto op = bir::VarDeclareOp::create(
+  auto op = bir::DeclareOp::create(
       builder, loc, refType, llvm::StringRef(name.data(), name.size()));
   return std::make_unique<BIRValue>(op.getResult());
 }
@@ -161,7 +161,7 @@ std::unique_ptr<BIRValue> BIRGen::build_var_declare_ty(TypeKind v,
 void BIRGen::build_var_store(const BIRValue &v, const BIRValue &ref) {
   auto src = v.getValue();
   auto dest = ref.getValue();
-  bir::VarStoreOp::create(builder, loc, src, dest);
+  bir::StoreOp::create(builder, loc, src, dest);
 }
 
 std::unique_ptr<BIRValue> BIRGen::build_var_load(const BIRValue &refValue) {

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -411,11 +411,11 @@ struct ShrOpLowering final : public OpConversionPattern<bir::ShrOp> {
   }
 };
 
-struct VarDeclareOpLowering final : public OpConversionPattern<bir::VarDeclareOp> {
-  using OpConversionPattern<bir::VarDeclareOp>::OpConversionPattern;
+struct DeclareOpLowering final : public OpConversionPattern<bir::DeclareOp> {
+  using OpConversionPattern<bir::DeclareOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(bir::VarDeclareOp op, OpAdaptor adaptor,
+  matchAndRewrite(bir::DeclareOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto refType = mlir::cast<bir::RefType>(op.getType());
     auto elType = refType.getEl();
@@ -462,11 +462,11 @@ struct VarDeclareOpLowering final : public OpConversionPattern<bir::VarDeclareOp
   };
 };
 
-struct VarStoreOpLowering final : public OpConversionPattern<bir::VarStoreOp> {
-  using OpConversionPattern<bir::VarStoreOp>::OpConversionPattern;
+struct StoreOpLowering final : public OpConversionPattern<bir::StoreOp> {
+  using OpConversionPattern<bir::StoreOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(bir::VarStoreOp op, OpAdaptor adaptor,
+  matchAndRewrite(bir::StoreOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (auto str = llvm::dyn_cast<bir::StringType>(adaptor.getSrc().getType())) {
       auto type = getTypeConverter()->convertType(adaptor.getSrc().getType());
@@ -651,7 +651,7 @@ void belalang::bir::populateBelalangBIRToLLVMPatterns(
                CallIndirectOpLowering, ReturnOpLowering, AddOpLowering,
                SubOpLowering, MulOpLowering, DivOpLowering, ModOpLowering,
                AndOpLowering, OrOpLowering, XorOpLowering, ShlOpLowering,
-               ShrOpLowering, VarDeclareOpLowering, VarStoreOpLowering,
+               ShrOpLowering, DeclareOpLowering, StoreOpLowering,
                VarLoadOpLowering, CondBrLowering, CmpOpLowering,
                GetMemberOpLowering>(
       typeConverter, patterns.getContext());

--- a/tests/BIR/IR/variables.mlir
+++ b/tests/BIR/IR/variables.mlir
@@ -2,10 +2,10 @@
 
 // CHECK: bir.func
 bir.func @main() -> !bir.int {
-  %0 = bir.var.declare "x" : !bir.ref<!bir.int>
+  %0 = bir.declare "x" : !bir.ref<!bir.int>
   %1 = bir.constant #bir.int<12> : !bir.int
-  bir.var.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
-  %2 = bir.var.load %0 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
+  %2 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int
   bir.return %2 : !bir.int
 }
 
@@ -14,13 +14,13 @@ bir.func @main() -> !bir.int {
 // CHECK: bir.func
 bir.func @main() -> !bir.int {
   // x := 12
-  %0 = bir.var.declare "x" : !bir.ref<!bir.int>
+  %0 = bir.declare "x" : !bir.ref<!bir.int>
   %1 = bir.constant #bir.int<12> : !bir.int
-  bir.var.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
+  bir.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
 
   // return x + 1
   %2 = bir.constant #bir.int<1> : !bir.int
-  %3 = bir.var.load %0 : (!bir.ref<!bir.int>) -> !bir.int
+  %3 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int
   %4 = bir.add %3, %2 : (!bir.int, !bir.int) -> !bir.int
   bir.return %4 : !bir.int
 }
@@ -31,10 +31,10 @@ bir.func @main() -> !bir.int {
 bir.func @main() -> !bir.string {
   // x := "hello"
   %0 = bir.constant #bir.string<"hello"> : !bir.string
-  %1 = bir.var.declare "x" :!bir.ref<!bir.string>
-  bir.var.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
+  %1 = bir.declare "x" :!bir.ref<!bir.string>
+  bir.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
 
   // return x
-  %2 = bir.var.load %1 : (!bir.ref<!bir.string>) -> !bir.string
+  %2 = bir.load %1 : (!bir.ref<!bir.string>) -> !bir.string
   bir.return %2 : !bir.string
 }

--- a/tests/BIR/Target/LLVMIR/string.mlir
+++ b/tests/BIR/Target/LLVMIR/string.mlir
@@ -19,11 +19,11 @@
 bir.func @main() -> !bir.string {
   // x := "hello"
   %0 = bir.constant #bir.string<"hello"> : !bir.string
-  %1 = bir.var.declare "x" : !bir.ref<!bir.string>
-  bir.var.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
+  %1 = bir.declare "x" : !bir.ref<!bir.string>
+  bir.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
 
   // return x
-  %2 = bir.var.load %1 : (!bir.ref<!bir.string>) -> !bir.string
+  %2 = bir.load %1 : (!bir.ref<!bir.string>) -> !bir.string
   bir.return %2 : !bir.string
 }
 
@@ -49,11 +49,11 @@ bir.func @main() -> !bir.string {
 bir.func @main() {
   // x := "hello"
   %0 = bir.constant #bir.string<"hello"> : !bir.string
-  %1 = bir.var.declare "x" : !bir.ref<!bir.string>
-  bir.var.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
+  %1 = bir.declare "x" : !bir.ref<!bir.string>
+  bir.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
 
   // print(x)
-  %2 = bir.var.load %1 : (!bir.ref<!bir.string>) -> !bir.string
+  %2 = bir.load %1 : (!bir.ref<!bir.string>) -> !bir.string
   bir.print %2 : !bir.string
   bir.return
 }

--- a/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
@@ -74,10 +74,10 @@ bir.func @main() -> !bir.int {
 // CHECK: llvm.return %[[LOAD]] : i64
 
 bir.func @main() -> !bir.int {
-  %0 = bir.var.declare "x" : !bir.ref<!bir.int>
+  %0 = bir.declare "x" : !bir.ref<!bir.int>
   %1 = bir.constant #bir.int<12> : !bir.int
-  bir.var.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
-  %2 = bir.var.load %0 : (!bir.ref<!bir.int>) -> !bir.int
+  bir.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
+  %2 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int
   bir.return %2 : !bir.int
 }
 

--- a/tests/BIRGen/block_yield.bel
+++ b/tests/BIRGen/block_yield.bel
@@ -13,5 +13,5 @@ x: Int = {
 # CHECK-NEXT:   %[[C3:.*]] = bir.constant #bir.int<42> : !bir.int
 # CHECK-NEXT:   cf.br ^bb2(%[[C3]] : !bir.int)
 # CHECK-NEXT: ^bb2(%[[VAL:.*]]: !bir.int):  // pred: ^bb1
-# CHECK-NEXT:   %[[VAR:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
-# CHECK-NEXT:   bir.var.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:   %[[VAR:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:   bir.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>

--- a/tests/BIRGen/functions.bel
+++ b/tests/BIRGen/functions.bel
@@ -4,27 +4,27 @@
 # CHECK-NEXT:   bir.func private @brt_print_int(!bir.int)
 # CHECK-NEXT:   bir.func @brt_init()
 # CHECK-NEXT:   bir.func @fn.main.anon(%[[ARG0:.*]]: !bir.int, %[[ARG1:.*]]: !bir.int) -> !bir.int {
-# CHECK-NEXT:     %[[V0:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
-# CHECK-NEXT:     bir.var.store %[[ARG0]] to %[[V0]] : !bir.int to !bir.ref<!bir.int>
-# CHECK-NEXT:     %[[V1:.*]] = bir.var.declare "y" : !bir.ref<!bir.int>
-# CHECK-NEXT:     bir.var.store %[[ARG1]] to %[[V1]] : !bir.int to !bir.ref<!bir.int>
-# CHECK-NEXT:     %[[V2:.*]] = bir.var.load %[[V0]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT:     %[[V3:.*]] = bir.var.load %[[V1]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT:     %[[V0:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:     bir.store %[[ARG0]] to %[[V0]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[V1:.*]] = bir.declare "y" : !bir.ref<!bir.int>
+# CHECK-NEXT:     bir.store %[[ARG1]] to %[[V1]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[V2:.*]] = bir.load %[[V0]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT:     %[[V3:.*]] = bir.load %[[V1]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     %[[V4:.*]] = bir.add %[[V2]], %[[V3]] : (!bir.int, !bir.int) -> !bir.int
 # CHECK-NEXT:     bir.return %[[V4]] : !bir.int
 # CHECK-NEXT:   }
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
 # CHECK-NEXT:     %[[C0:.*]] = bir.constant #bir.fn<@fn.main.anon> : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     %[[V5:.*]] = bir.var.declare "add" : !bir.ref<(!bir.int, !bir.int) -> !bir.int>
-# CHECK-NEXT:     bir.var.store %[[C0]] to %[[V5]] : (!bir.int, !bir.int) -> !bir.int to !bir.ref<(!bir.int, !bir.int) -> !bir.int>
-# CHECK-NEXT:     %[[V6:.*]] = bir.var.load %[[V5]] : (!bir.ref<(!bir.int, !bir.int) -> !bir.int>) -> ((!bir.int, !bir.int) -> !bir.int)
+# CHECK-NEXT:     %[[V5:.*]] = bir.declare "add" : !bir.ref<(!bir.int, !bir.int) -> !bir.int>
+# CHECK-NEXT:     bir.store %[[C0]] to %[[V5]] : (!bir.int, !bir.int) -> !bir.int to !bir.ref<(!bir.int, !bir.int) -> !bir.int>
+# CHECK-NEXT:     %[[V6:.*]] = bir.load %[[V5]] : (!bir.ref<(!bir.int, !bir.int) -> !bir.int>) -> ((!bir.int, !bir.int) -> !bir.int)
 # CHECK-NEXT:     %[[C1:.*]] = bir.constant #bir.int<2> : !bir.int
 # CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<3> : !bir.int
 # CHECK-NEXT:     %[[C3:.*]] = bir.call_indirect %[[V6]](%[[C1]], %[[C2]]) : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     %[[V7:.*]] = bir.var.declare "p" : !bir.ref<!bir.int>
-# CHECK-NEXT:     bir.var.store %[[C3]] to %[[V7]] : !bir.int to !bir.ref<!bir.int>
-# CHECK-NEXT:     %[[V8:.*]] = bir.var.load %[[V7]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT:     %[[V7:.*]] = bir.declare "p" : !bir.ref<!bir.int>
+# CHECK-NEXT:     bir.store %[[C3]] to %[[V7]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[V8:.*]] = bir.load %[[V7]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     bir.call @brt_print_int(%[[V8]]) : (!bir.int) -> ()
 # CHECK-NEXT:     %[[C4:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C4]] : !bir.int

--- a/tests/BIRGen/if_yield.bel
+++ b/tests/BIRGen/if_yield.bel
@@ -15,5 +15,5 @@ x: Int = if true {
 # CHECK-NEXT:   %[[C3:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:   cf.br ^bb3(%[[C3]] : !bir.int)
 # CHECK-NEXT: ^bb3(%[[VAL:.*]]: !bir.int):  // 2 preds: ^bb1, ^bb2
-# CHECK-NEXT:   %[[VAR:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
-# CHECK-NEXT:   bir.var.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:   %[[VAR:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:   bir.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>

--- a/tests/BIRGen/string.bel
+++ b/tests/BIRGen/string.bel
@@ -5,8 +5,8 @@
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
 # CHECK-NEXT:     %0 = bir.constant #bir.string<"hello"> : !bir.string
-# CHECK-NEXT:     %1 = bir.var.declare "x" : !bir.ref<!bir.string>
-# CHECK-NEXT:     bir.var.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
+# CHECK-NEXT:     %1 = bir.declare "x" : !bir.ref<!bir.string>
+# CHECK-NEXT:     bir.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
 # CHECK-NEXT:     %2 = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %2 : !bir.int
 # CHECK-NEXT:   }

--- a/tests/BIRGen/variable_declaration.bel
+++ b/tests/BIRGen/variable_declaration.bel
@@ -7,8 +7,8 @@ y: String
 # CHECK-NEXT:   bir.func @brt_init()
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
-# CHECK-NEXT:     %[[C0:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
-# CHECK-NEXT:     %[[C1:.*]] = bir.var.declare "y" : !bir.ref<!bir.string>
+# CHECK-NEXT:     %[[C0:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[C1:.*]] = bir.declare "y" : !bir.ref<!bir.string>
 # CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C2]] : !bir.int
 # CHECK-NEXT:   }

--- a/tests/BIRGen/variables.bel
+++ b/tests/BIRGen/variables.bel
@@ -7,35 +7,35 @@
 # CHECK-NEXT:   bir.call @brt_init() : () -> ()
 
 # CHECK-NEXT: %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT: %[[C1:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
-# CHECK-NEXT: bir.var.store %[[C0]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT: %[[C1:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT: bir.store %[[C0]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 
 x := 1;
 
 # CHECK-NEXT: %[[C2:.*]] = bir.constant #bir.float<1.000000e+00> : !bir.float
-# CHECK-NEXT: %[[C3:.*]] = bir.var.declare "y" : !bir.ref<!bir.float>
-# CHECK-NEXT: bir.var.store %[[C2]] to %[[C3]] : !bir.float to !bir.ref<!bir.float>
+# CHECK-NEXT: %[[C3:.*]] = bir.declare "y" : !bir.ref<!bir.float>
+# CHECK-NEXT: bir.store %[[C2]] to %[[C3]] : !bir.float to !bir.ref<!bir.float>
 y := 1.0;
 
-# CHECK-NEXT: %[[C4:.*]] = bir.var.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT: %[[C4:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT: %[[C5:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C6:.*]] = bir.add %[[C4]], %[[C5]] : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT: %[[C7:.*]] = bir.var.declare "z" : !bir.ref<!bir.int>
-# CHECK-NEXT: bir.var.store %[[C6]] to %[[C7]] : !bir.int to !bir.ref<!bir.int>
-# CHECK-NEXT: %[[C8:.*]] = bir.var.load %[[C7]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT: %[[C7:.*]] = bir.declare "z" : !bir.ref<!bir.int>
+# CHECK-NEXT: bir.store %[[C6]] to %[[C7]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT: %[[C8:.*]] = bir.load %[[C7]] : (!bir.ref<!bir.int>) -> !bir.int
 z := x + 1;
 
 # CHECK-NEXT: bir.call @brt_print_int(%[[C8]]) : (!bir.int) -> ()
 print(z);
 
 # CHECK-NEXT: %[[C10:.*]] = bir.constant #bir.int<10> : !bir.int
-# CHECK-NEXT: bir.var.store %[[C10]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT: bir.store %[[C10]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x = 10;
 
 # CHECK-NEXT: %[[C11:.*]] = bir.constant #bir.int<5> : !bir.int
-# CHECK-NEXT: %[[C12:.*]] = bir.var.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT: %[[C12:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT: %[[C13:.*]] = bir.add %[[C12]], %[[C11]] : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT: bir.var.store %[[C13]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT: bir.store %[[C13]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x += 5;
 
 # CHECK-NEXT: %[[C14:.*]] = bir.constant #bir.int<0> : !bir.int

--- a/tests/BIRGen/while-loops.bel
+++ b/tests/BIRGen/while-loops.bel
@@ -5,11 +5,11 @@
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
 # CHECK-NEXT:     %[[C0:.*]] = bir.constant #bir.int<0> : !bir.int
-# CHECK-NEXT:     %[[X:.*]] = bir.var.declare "x" : !bir.ref<!bir.int>
-# CHECK-NEXT:     bir.var.store %[[C0]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[X:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:     bir.store %[[C0]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     cf.br ^bb1
 # CHECK-NEXT:   ^bb1:  // 2 preds: ^bb0, ^bb4
-# CHECK-NEXT:     %[[L1:.*]] = bir.var.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT:     %[[L1:.*]] = bir.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     %[[C5:.*]] = bir.constant #bir.int<5> : !bir.int
 # CHECK-NEXT:     %[[COND:.*]] = bir.cmp lt %[[L1]], %[[C5]] : !bir.int
 # CHECK-NEXT:     bir.cond_br %[[COND]] ^bb2, ^bb5
@@ -17,9 +17,9 @@
 # CHECK-NEXT:     cf.br ^bb3
 # CHECK-NEXT:   ^bb3:  // pred: ^bb2
 # CHECK-NEXT:     %[[C1:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT:     %[[L2:.*]] = bir.var.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT:     %[[L2:.*]] = bir.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     %[[ADD:.*]] = bir.add %[[L2]], %[[C1]] : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     bir.var.store %[[ADD]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:     bir.store %[[ADD]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     cf.br ^bb4
 # CHECK-NEXT:   ^bb4:  // pred: ^bb3
 # CHECK-NEXT:     cf.br ^bb1


### PR DESCRIPTION
The `var.` naming semantics on `var.store` and `var.load` doesn't make sense. Both ops deal with pointers and not just variables. As for `var.declare` it does declare variables, but it can also declare functions, which to be fair are variables, but to make the op more generic, I decided to also remove the `var.` prefix on that.