### PR TITLE
[bir] AllocHeapOp and LowerDeclToMemoryPass

### DIFF
--- a/bir/BUILD.bazel
+++ b/bir/BUILD.bazel
@@ -154,6 +154,7 @@ cc_library(
         "lib/IR/BIRTypes.cpp",
         "lib/Pipelines.cpp",
         "lib/Interfaces/LoopOpInterface.cpp",
+        "lib/Transforms/LowerDeclToMemory.cpp",
         "lib/Transforms/LowerPrintToRuntime.cpp",
         "lib/Transforms/PrepareRuntime.cpp",
         "lib/Transforms/FlattenCFG.cpp",

--- a/bir/include/belalang/BIR/IR/BIROps.td
+++ b/bir/include/belalang/BIR/IR/BIROps.td
@@ -557,4 +557,20 @@ def BIR_GetMemberOp : BIR_Op<"get_member"> {
   let hasBIRGenBindings = false; // TODO: make bindings
 }
 
+def BIR_AllocHeapOp : BIR_Op<"alloc_heap"> {
+  let arguments = (ins 
+    I64Attr:$size
+  );
+
+  let results = (outs
+    BIR_RefType:$result
+  );
+
+  let assemblyFormat = [{
+    $size `:` qualified(type($result)) attr-dict
+  }];
+
+  let hasBIRGenBindings = false; // TODO: make bindings
+}
+
 #endif // BELALANG_IR_OPS_TD_

--- a/bir/include/belalang/BIR/Passes.h
+++ b/bir/include/belalang/BIR/Passes.h
@@ -17,6 +17,7 @@ namespace bir {
 #include "belalang/BIR/Passes.h.inc"
 
 void populateBelalangFlattenCFGPatterns(mlir::RewritePatternSet &patterns);
+void populateBelalangLowerDeclToMemoryPatterns(mlir::RewritePatternSet &patterns);
 void populateBelalangLowerFuncExprPatterns(mlir::RewritePatternSet &patterns);
 void populateBelalangLowerPrintToRuntimePatterns(mlir::RewritePatternSet &patterns);
 void populateBelalangBIRToLLVMPatterns(mlir::RewritePatternSet &patterns,

--- a/bir/include/belalang/BIR/Passes.td
+++ b/bir/include/belalang/BIR/Passes.td
@@ -19,6 +19,11 @@ def BelalangLowerFuncExprPass : Pass<"bir-lower-func-expr"> {
   let dependentDialects = ["::belalang::bir::BIRDialect"];
 }
 
+def BelalangLowerDeclToMemoryPass : Pass<"bir-lower-decl-to-memory"> {
+  let summary = "lowers declare ops to memory";
+  let dependentDialects = ["::belalang::bir::BIRDialect"];
+}
+
 def BelalangPrepareRuntimePass : Pass<"bir-prepare-runtime"> {
   let summary = "Lower ops to calls to runtime library";
   let dependentDialects = ["::belalang::bir::BIRDialect"];

--- a/bir/lib/Pipelines.cpp
+++ b/bir/lib/Pipelines.cpp
@@ -12,6 +12,7 @@ void buildBIRLoweringPipeline(mlir::OpPassManager &pm,
   pm.addPass(createBelalangLowerFuncExprPass());
   pm.addPass(createBelalangPrepareRuntimePass());
   pm.addPass(createBelalangLowerPrintToRuntimePass());
+  pm.addPass(createBelalangLowerDeclToMemoryPass());
   pm.addPass(createBelalangFlattenCFGPass());
 }
 

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -411,30 +411,15 @@ struct ShrOpLowering final : public OpConversionPattern<bir::ShrOp> {
   }
 };
 
-struct DeclareOpLowering final : public OpConversionPattern<bir::DeclareOp> {
-  using OpConversionPattern<bir::DeclareOp>::OpConversionPattern;
+struct AllocHeapOpLowering final : public OpConversionPattern<bir::AllocHeapOp> {
+  using OpConversionPattern<bir::AllocHeapOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(bir::DeclareOp op, OpAdaptor adaptor,
+  matchAndRewrite(bir::AllocHeapOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto refType = mlir::cast<bir::RefType>(op.getType());
-    auto elType = refType.getEl();
+    auto elSize = op.getSize();
     auto loc = op.getLoc();
     auto ctx = op.getContext();
-
-    int64_t elSize;
-    if (mlir::isa<bir::IntType>(elType))
-      elSize = 8;
-    else if (mlir::isa<bir::FloatType>(elType))
-      elSize = 8;
-    else if (mlir::isa<bir::StringType>(elType))
-      elSize = 16;
-    else if (mlir::isa<bir::BoolType>(elType))
-      elSize = 8;
-    else if (mlir::isa<mlir::FunctionType>(elType))
-      elSize = 8;
-    else
-      return failure();
 
     auto module = op->getParentOfType<mlir::ModuleOp>();
     if (!module.lookupSymbol(kGCAlloc)) {
@@ -651,7 +636,7 @@ void belalang::bir::populateBelalangBIRToLLVMPatterns(
                CallIndirectOpLowering, ReturnOpLowering, AddOpLowering,
                SubOpLowering, MulOpLowering, DivOpLowering, ModOpLowering,
                AndOpLowering, OrOpLowering, XorOpLowering, ShlOpLowering,
-               ShrOpLowering, DeclareOpLowering, StoreOpLowering,
+               ShrOpLowering, AllocHeapOpLowering, StoreOpLowering,
                VarLoadOpLowering, CondBrLowering, CmpOpLowering,
                GetMemberOpLowering>(
       typeConverter, patterns.getContext());

--- a/bir/lib/Transforms/LowerDeclToMemory.cpp
+++ b/bir/lib/Transforms/LowerDeclToMemory.cpp
@@ -1,0 +1,75 @@
+#include "belalang/BIR/IR/BIR.h"
+#include "belalang/BIR/Passes.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_BELALANGLOWERDECLTOMEMORYPASS
+#include "belalang/BIR/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+
+using namespace belalang;
+using namespace belalang::bir;
+
+struct DeclareOpLowering final : public OpRewritePattern<bir::DeclareOp> {
+  using OpRewritePattern<bir::DeclareOp>::OpRewritePattern;
+
+  LogicalResult
+  matchAndRewrite(bir::DeclareOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto refType = mlir::cast<bir::RefType>(op.getType());
+    auto elType = refType.getEl();
+
+    int64_t elSize;
+    if (mlir::isa<bir::IntType>(elType))
+      elSize = 8;
+    else if (mlir::isa<bir::FloatType>(elType))
+      elSize = 8;
+    else if (mlir::isa<bir::StringType>(elType))
+      elSize = 16;
+    else if (mlir::isa<bir::BoolType>(elType))
+      elSize = 8;
+    else if (mlir::isa<mlir::FunctionType>(elType))
+      elSize = 8;
+    else
+      return failure();
+
+    mlir::Type ty = op.getResult().getType();
+    rewriter.replaceOpWithNewOp<bir::AllocHeapOp>(op, ty, elSize);
+    return success();
+  };
+};
+
+} // namespace
+
+void belalang::bir::populateBelalangLowerDeclToMemoryPatterns(
+    mlir::RewritePatternSet &patterns) {
+  patterns.add<DeclareOpLowering>(patterns.getContext());
+}
+
+// -----------------------------------------------------------------------------
+// The Pass
+// -----------------------------------------------------------------------------
+
+struct BelalangLowerDeclToMemoryPass
+    : public impl::BelalangLowerDeclToMemoryPassBase<
+          BelalangLowerDeclToMemoryPass> {
+  using impl::BelalangLowerDeclToMemoryPassBase<
+      BelalangLowerDeclToMemoryPass>::BelalangLowerDeclToMemoryPassBase;
+
+  void runOnOperation() override {
+    mlir::RewritePatternSet patterns(&getContext());
+    belalang::bir::populateBelalangLowerDeclToMemoryPatterns(patterns);
+
+    if (mlir::applyPatternsGreedily(getOperation(), std::move(patterns))
+            .failed()) {
+      signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<mlir::Pass>
+belalang::bir::createBelalangLowerDeclToMemoryPass() {
+  return std::make_unique<BelalangLowerDeclToMemoryPass>();
+}

--- a/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
@@ -74,7 +74,7 @@ bir.func @main() -> !bir.int {
 // CHECK: llvm.return %[[LOAD]] : i64
 
 bir.func @main() -> !bir.int {
-  %0 = bir.declare "x" : !bir.ref<!bir.int>
+  %0 = bir.alloc_heap 8 : !bir.ref<!bir.int>
   %1 = bir.constant #bir.int<12> : !bir.int
   bir.store %1 to %0 : !bir.int to !bir.ref<!bir.int>
   %2 = bir.load %0 : (!bir.ref<!bir.int>) -> !bir.int

--- a/tests/BIRGen/block_yield.bel
+++ b/tests/BIRGen/block_yield.bel
@@ -13,5 +13,5 @@ x: Int = {
 # CHECK-NEXT:   %[[C3:.*]] = bir.constant #bir.int<42> : !bir.int
 # CHECK-NEXT:   cf.br ^bb2(%[[C3]] : !bir.int)
 # CHECK-NEXT: ^bb2(%[[VAL:.*]]: !bir.int):  // pred: ^bb1
-# CHECK-NEXT:   %[[VAR:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:   %[[VAR:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT:   bir.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>

--- a/tests/BIRGen/functions.bel
+++ b/tests/BIRGen/functions.bel
@@ -4,9 +4,9 @@
 # CHECK-NEXT:   bir.func private @brt_print_int(!bir.int)
 # CHECK-NEXT:   bir.func @brt_init()
 # CHECK-NEXT:   bir.func @fn.main.anon(%[[ARG0:.*]]: !bir.int, %[[ARG1:.*]]: !bir.int) -> !bir.int {
-# CHECK-NEXT:     %[[V0:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[V0:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT:     bir.store %[[ARG0]] to %[[V0]] : !bir.int to !bir.ref<!bir.int>
-# CHECK-NEXT:     %[[V1:.*]] = bir.declare "y" : !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[V1:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT:     bir.store %[[ARG1]] to %[[V1]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     %[[V2:.*]] = bir.load %[[V0]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     %[[V3:.*]] = bir.load %[[V1]] : (!bir.ref<!bir.int>) -> !bir.int
@@ -16,13 +16,13 @@
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
 # CHECK-NEXT:     %[[C0:.*]] = bir.constant #bir.fn<@fn.main.anon> : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     %[[V5:.*]] = bir.declare "add" : !bir.ref<(!bir.int, !bir.int) -> !bir.int>
+# CHECK-NEXT:     %[[V5:.*]] = bir.alloc_heap 8 : !bir.ref<(!bir.int, !bir.int) -> !bir.int>
 # CHECK-NEXT:     bir.store %[[C0]] to %[[V5]] : (!bir.int, !bir.int) -> !bir.int to !bir.ref<(!bir.int, !bir.int) -> !bir.int>
 # CHECK-NEXT:     %[[V6:.*]] = bir.load %[[V5]] : (!bir.ref<(!bir.int, !bir.int) -> !bir.int>) -> ((!bir.int, !bir.int) -> !bir.int)
 # CHECK-NEXT:     %[[C1:.*]] = bir.constant #bir.int<2> : !bir.int
 # CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<3> : !bir.int
 # CHECK-NEXT:     %[[C3:.*]] = bir.call_indirect %[[V6]](%[[C1]], %[[C2]]) : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     %[[V7:.*]] = bir.declare "p" : !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[V7:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT:     bir.store %[[C3]] to %[[V7]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     %[[V8:.*]] = bir.load %[[V7]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT:     bir.call @brt_print_int(%[[V8]]) : (!bir.int) -> ()

--- a/tests/BIRGen/if_yield.bel
+++ b/tests/BIRGen/if_yield.bel
@@ -15,5 +15,5 @@ x: Int = if true {
 # CHECK-NEXT:   %[[C3:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:   cf.br ^bb3(%[[C3]] : !bir.int)
 # CHECK-NEXT: ^bb3(%[[VAL:.*]]: !bir.int):  // 2 preds: ^bb1, ^bb2
-# CHECK-NEXT:   %[[VAR:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:   %[[VAR:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT:   bir.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>

--- a/tests/BIRGen/string.bel
+++ b/tests/BIRGen/string.bel
@@ -5,7 +5,7 @@
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
 # CHECK-NEXT:     %0 = bir.constant #bir.string<"hello"> : !bir.string
-# CHECK-NEXT:     %1 = bir.declare "x" : !bir.ref<!bir.string>
+# CHECK-NEXT:     %1 = bir.alloc_heap 16 : !bir.ref<!bir.string>
 # CHECK-NEXT:     bir.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
 # CHECK-NEXT:     %2 = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %2 : !bir.int

--- a/tests/BIRGen/variable_declaration.bel
+++ b/tests/BIRGen/variable_declaration.bel
@@ -7,8 +7,8 @@ y: String
 # CHECK-NEXT:   bir.func @brt_init()
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
-# CHECK-NEXT:     %[[C0:.*]] = bir.declare "x" : !bir.ref<!bir.int>
-# CHECK-NEXT:     %[[C1:.*]] = bir.declare "y" : !bir.ref<!bir.string>
+# CHECK-NEXT:     %[[C0:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[C1:.*]] = bir.alloc_heap 16 : !bir.ref<!bir.string>
 # CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C2]] : !bir.int
 # CHECK-NEXT:   }

--- a/tests/BIRGen/variables.bel
+++ b/tests/BIRGen/variables.bel
@@ -7,20 +7,20 @@
 # CHECK-NEXT:   bir.call @brt_init() : () -> ()
 
 # CHECK-NEXT: %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT: %[[C1:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT: %[[C1:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT: bir.store %[[C0]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 
 x := 1;
 
 # CHECK-NEXT: %[[C2:.*]] = bir.constant #bir.float<1.000000e+00> : !bir.float
-# CHECK-NEXT: %[[C3:.*]] = bir.declare "y" : !bir.ref<!bir.float>
+# CHECK-NEXT: %[[C3:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.float>
 # CHECK-NEXT: bir.store %[[C2]] to %[[C3]] : !bir.float to !bir.ref<!bir.float>
 y := 1.0;
 
 # CHECK-NEXT: %[[C4:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT: %[[C5:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C6:.*]] = bir.add %[[C4]], %[[C5]] : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT: %[[C7:.*]] = bir.declare "z" : !bir.ref<!bir.int>
+# CHECK-NEXT: %[[C7:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT: bir.store %[[C6]] to %[[C7]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT: %[[C8:.*]] = bir.load %[[C7]] : (!bir.ref<!bir.int>) -> !bir.int
 z := x + 1;

--- a/tests/BIRGen/while-loops.bel
+++ b/tests/BIRGen/while-loops.bel
@@ -5,7 +5,7 @@
 # CHECK-NEXT:   bir.func @main() -> !bir.int {
 # CHECK-NEXT:     bir.call @brt_init() : () -> ()
 # CHECK-NEXT:     %[[C0:.*]] = bir.constant #bir.int<0> : !bir.int
-# CHECK-NEXT:     %[[X:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[X:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT:     bir.store %[[C0]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     cf.br ^bb1
 # CHECK-NEXT:   ^bb1:  // 2 preds: ^bb0, ^bb4


### PR DESCRIPTION
The `bir.declare` op is still high-level. Seeing it in BIR outputs doesn't really tell much about what the program will do in memory. This change introduces the AllocHeapOp and LowerDeclToMemory. The idea is that high-level `bir.declare` gets lowered to `bir.alloc_heap` which has a size property. On top of that, it allows us to look into stack allocation and not only heap allocation. There may be some analyses that could be implemented in LowerDeclToMemory to figure out when to heap alloc and when to stack alloc.