### PR TITLE
[bir] Rename el to referent in `bir.ref`

### DIFF
--- a/bir/include/belalang/BIR/IR/BIRTypes.td
+++ b/bir/include/belalang/BIR/IR/BIRTypes.td
@@ -36,12 +36,21 @@ def BIR_StructType : BIR_Type<"Struct", "struct"> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def BIR_ReferencableType : AnyTypeOf<[
+  BIR_IntType,
+  BIR_FloatType,
+  BIR_StringType,
+  FunctionType,
+  BIR_BoolType,
+  BIR_StructType
+]>;
+
 def BIR_RefType : BIR_Type<"Ref", "ref"> {
   let summary = "Reference type";
 
-  let parameters = (ins AnyTypeOf<[BIR_IntType, BIR_FloatType, BIR_StringType, FunctionType, BIR_BoolType, BIR_StructType]>:$el);
+  let parameters = (ins BIR_ReferencableType:$referent);
 
-  let assemblyFormat = "`<` $el `>`";
+  let assemblyFormat = "`<` $referent `>`";
 }
 
 #endif // BELALANG_IR_TYPES_TD_

--- a/bir/lib/CodeGen/BIRGen.cpp
+++ b/bir/lib/CodeGen/BIRGen.cpp
@@ -171,7 +171,7 @@ std::unique_ptr<BIRValue> BIRGen::build_var_load(const BIRValue &refValue) {
   if (!refType)
     return nullptr;
 
-  auto resultType = refType.getEl();
+  auto resultType = refType.getReferent();
 
   auto op =
       bir::VarLoadOp::create(builder, loc, resultType, refValue.getValue());

--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -579,9 +579,9 @@ struct GetMemberOpLowering final : public OpConversionPattern<bir::GetMemberOp> 
   matchAndRewrite(bir::GetMemberOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     mlir::Type llvmResTy = getTypeConverter()->convertType(op.getType());
-    mlir::Type pointee = op.getAddr().getType().getEl();
+    mlir::Type referent = op.getAddr().getType().getReferent();
 
-    auto structTy = mlir::cast<bir::StructType>(pointee);
+    auto structTy = mlir::cast<bir::StructType>(referent);
     llvm::SmallVector<mlir::LLVM::GEPArg, 2> offset{0, op.getIndexAttr().getZExtValue()};
     const mlir::Type elementTy = getTypeConverter()->convertType(structTy);
     mlir::LLVM::GEPNoWrapFlags flags = 

--- a/bir/lib/Transforms/LowerDeclToMemory.cpp
+++ b/bir/lib/Transforms/LowerDeclToMemory.cpp
@@ -19,18 +19,18 @@ struct DeclareOpLowering final : public OpRewritePattern<bir::DeclareOp> {
   matchAndRewrite(bir::DeclareOp op,
                   mlir::PatternRewriter &rewriter) const override {
     auto refType = mlir::cast<bir::RefType>(op.getType());
-    auto elType = refType.getEl();
+    auto referentTy = refType.getReferent();
 
     int64_t elSize;
-    if (mlir::isa<bir::IntType>(elType))
+    if (mlir::isa<bir::IntType>(referentTy))
       elSize = 8;
-    else if (mlir::isa<bir::FloatType>(elType))
+    else if (mlir::isa<bir::FloatType>(referentTy))
       elSize = 8;
-    else if (mlir::isa<bir::StringType>(elType))
+    else if (mlir::isa<bir::StringType>(referentTy))
       elSize = 16;
-    else if (mlir::isa<bir::BoolType>(elType))
+    else if (mlir::isa<bir::BoolType>(referentTy))
       elSize = 8;
-    else if (mlir::isa<mlir::FunctionType>(elType))
+    else if (mlir::isa<mlir::FunctionType>(referentTy))
       elSize = 8;
     else
       return failure();


### PR DESCRIPTION
The `el` parameter in `bir.ref` used to stand for element. Though, lately it has been a bad name choice because it does not reflect what it really means. This change renames the `el` parameter to `referent` which is more self-explanatory. This change also adds a `BIR_ReferencableType` that refers to types that can be used with `bir.ref`. It could be that all types are referencable, but having an explicit type for now helps visualize things better in my opinion.