### PR TITLE
[lexer][ast] Implement import statement

### DIFF
--- a/ast/src/dump.rs
+++ b/ast/src/dump.rs
@@ -10,6 +10,7 @@ use super::{
     FunctionLiteral,
     Identifier,
     IfExpression,
+    ImportStatement,
     IndexExpression,
     InfixExpression,
     IntegerLiteral,
@@ -73,6 +74,11 @@ impl<'ast> Visitor<'ast> for ASTDumper<'_> {
 
     fn visit_continue_statement(&mut self, node: &crate::ContinueStatement) {
         println!("{:indent$}ContinueStatement", "", indent = self.indent);
+    }
+
+    fn visit_import_statement(&mut self, node: &ImportStatement) {
+        let module = self.session.lookup_string(node.module);
+        println!("{:indent$}ImportStatement({:?})", "", module, indent = self.indent);
     }
 
     fn visit_var_decl_statement(&mut self, node: &VarDeclStatement<'ast>) {

--- a/ast/src/parser.rs
+++ b/ast/src/parser.rs
@@ -34,6 +34,7 @@ use crate::{
     FunctionLiteral,
     Identifier,
     IfExpression,
+    ImportStatement,
     IndexExpression,
     InfixExpression,
     IntegerLiteral,
@@ -244,6 +245,29 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
                 Ok(Statement {
                     kind: StatementKind::While(WhileStatement { condition, block }),
+                    span,
+                })
+            },
+
+            // match `import`
+            TokenKind::Import => {
+                self.next_token()?; // curr_token should be import string
+
+                let module = if let TokenKind::Literal {
+                    kind: LiteralKind::String,
+                    sym,
+                } = self.curr_token.kind
+                {
+                    sym
+                } else {
+                    return Err(self.error_unexpected_token());
+                };
+
+                self.has_semicolon = optional_peek!(self, TokenKind::Semicolon);
+                let span = SourceSpan::new(start_span.start, self.curr_token.span.end);
+
+                Ok(Statement {
+                    kind: StatementKind::Import(ImportStatement { module }),
                     span,
                 })
             },

--- a/ast/src/statements.rs
+++ b/ast/src/statements.rs
@@ -43,6 +43,11 @@ pub struct StructDeclStatement<'ast> {
 }
 
 #[derive(Debug, Clone, Copy)]
+pub struct ImportStatement {
+    pub module: Symbol,
+}
+
+#[derive(Debug, Clone, Copy)]
 pub struct Statement<'ast> {
     pub kind: StatementKind<'ast>,
     pub span: SourceSpan,
@@ -55,6 +60,7 @@ pub enum StatementKind<'ast> {
     While(WhileStatement<'ast>),
     VarDecl(VarDeclStatement<'ast>),
     StructDecl(StructDeclStatement<'ast>),
+    Import(ImportStatement),
     Break(BreakStatement),
     Continue(ContinueStatement),
 }

--- a/ast/src/visitor.rs
+++ b/ast/src/visitor.rs
@@ -12,6 +12,7 @@ use super::{
     FunctionLiteral,
     Identifier,
     IfExpression,
+    ImportStatement,
     IndexExpression,
     InfixExpression,
     IntegerLiteral,
@@ -115,6 +116,10 @@ pub trait Visitor<'ast> {
 
     fn visit_continue_statement(&mut self, node: &ContinueStatement) {}
 
+    fn visit_import_statement(&mut self, node: &ImportStatement) {
+        self.walk_import_statement(node);
+    }
+
     fn visit_var_decl_statement(&mut self, node: &VarDeclStatement<'ast>) {
         self.walk_var_decl_statement(node);
     }
@@ -136,6 +141,7 @@ pub trait Visitor<'ast> {
             StatementKind::While(v) => self.visit_while_statement(v),
             StatementKind::VarDecl(v) => self.visit_var_decl_statement(v),
             StatementKind::StructDecl(v) => self.visit_struct_decl_statement(v),
+            StatementKind::Import(v) => self.visit_import_statement(v),
             StatementKind::Break(v) => self.visit_break_statement(v),
             StatementKind::Continue(v) => self.visit_continue_statement(v),
         }
@@ -235,6 +241,8 @@ pub trait Visitor<'ast> {
         self.visit_expression(&node.condition);
         self.visit_block(&node.block);
     }
+
+    fn walk_import_statement(&mut self, node: &ImportStatement) {}
 
     fn walk_var_decl_statement(&mut self, node: &VarDeclStatement<'ast>) {
         self.visit_identifier(&node.name);

--- a/birgen/src/lib.rs
+++ b/birgen/src/lib.rs
@@ -235,6 +235,9 @@ impl<'sess> BIRGen<'sess> {
             StatementKind::StructDecl(_s) => {
                 // TODO: Implement struct declaration
             },
+            StatementKind::Import(_s) => {
+                // TODO: Implement import statement
+            },
             StatementKind::Break(_s) => {
                 self.inner.pin_mut().build_break_op();
             },

--- a/lexer/src/lexer.rs
+++ b/lexer/src/lexer.rs
@@ -571,6 +571,7 @@ impl<'sess> Lexer<'sess> {
                     syms::ELSE => TokenKind::Else,
                     syms::RETURN => TokenKind::Return,
                     syms::STRUCT => TokenKind::Struct,
+                    syms::IMPORT => TokenKind::Import,
                     _ => TokenKind::Ident { sym },
                 };
 

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -114,6 +114,8 @@ pub enum TokenKind {
     Return,
     /// Struct keyword `struct`
     Struct,
+    /// Import keyword `import`
+    Import,
 
     /// Dot operator `.`
     Dot,
@@ -293,6 +295,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::If => "if",
             TokenKind::Else => "else",
             TokenKind::Return => "return",
+            TokenKind::Import => "import",
 
             TokenKind::Comma => ",",
             TokenKind::Semicolon => ";",

--- a/session/src/interner.rs
+++ b/session/src/interner.rs
@@ -39,9 +39,10 @@ pub mod syms {
     pub const STRUCT: Symbol = Symbol(11);
     pub const BREAK: Symbol = Symbol(12);
     pub const CONTINUE: Symbol = Symbol(13);
+    pub const IMPORT: Symbol = Symbol(14);
 
     // Built-ins
-    pub const PRINT: Symbol = Symbol(14);
+    pub const PRINT: Symbol = Symbol(15);
 }
 
 impl Interner {
@@ -65,6 +66,7 @@ impl Interner {
         s.intern("struct");
         s.intern("break");
         s.intern("continue");
+        s.intern("import");
 
         // Built-ins
         s.intern("print");

--- a/tests/AST/import.bel
+++ b/tests/AST/import.bel
@@ -1,0 +1,10 @@
+# RUN: %belalang build --emit ast %s | %FileCheck %s
+
+import "core:math"
+import "std:io"
+import "foo:bar"
+
+# CHECK:      Program
+# CHECK-NEXT:   ImportStatement("core:math")
+# CHECK-NEXT:   ImportStatement("std:io")
+# CHECK-NEXT:   ImportStatement("foo:bar")

--- a/tests/Tokens/import.bel
+++ b/tests/Tokens/import.bel
@@ -1,0 +1,11 @@
+# RUN: %belalang build --emit=tokens %s | %FileCheck %s
+
+import "core:math"
+import "std:io"
+import "foo:bar"
+# CHECK: Import <57..63>
+# CHECK: Literal(String, "core:math") <64..75>
+# CHECK: Import <76..82>
+# CHECK: Literal(String, "std:io") <83..91>
+# CHECK: Import <92..98>
+# CHECK: Literal(String, "foo:bar") <99..108>


### PR DESCRIPTION
This change implements the import statement in lexer and AST. The chosen syntax is:

```belalang
import "core:math"
```

This makes it easy to parse as its only an import token and a string literal. Work still needs to be done to lower the import statements to the correct BIR ops and by extension LLVM ops.

Closes #279 