### PR TITLE
[ci] Merge build and test to build-and-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ on:
     branches: ["main"]
 
 jobs:
-  test:
+  build-and-test:
     strategy:
       matrix:
         os: [ubuntu-latest]
-    name: Test
+    name: Build and Test
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -20,20 +20,7 @@ jobs:
           disk-cache: ${{ github.workflow }}
           repository-cache: true
           cache-save: ${{ github.event_name != 'pull_request' }}
-      - run: bazel test //...
-
-  build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    name: Build
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: bazel-contrib/setup-bazel@0.19.0
-        with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
-          repository-cache: true
-          cache-save: ${{ github.event_name != 'pull_request' }}
-      - run: bazel build //...
+      - name: Build
+        run: bazel build //...
+      - name: Test
+        run: bazel test //...


### PR DESCRIPTION
This change merges the two jobs into one build-and-test. Previous to this change, the CI was split into two jobs, build and test. I find that both jobs were running in parallel. From my experience as well, the test run won't take as much time if the build had already finished.