### PR TITLE
[bir] Use GlobalCtorsOp for initializing BRT

### DIFF
--- a/bir/lib/Transforms/BIRToLLVM.cpp
+++ b/bir/lib/Transforms/BIRToLLVM.cpp
@@ -5,6 +5,7 @@
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
@@ -624,6 +625,55 @@ struct BIRToLLVMTypeConverter : public mlir::LLVMTypeConverter {
   }
 };
 
+static void insertBRTInitCall(mlir::Operation *op) {
+  mlir::ModuleOp module = dyn_cast_or_null<mlir::ModuleOp>(op);
+  assert(module || "unexpected non-ModuleOp");
+  mlir::MLIRContext *ctx = module.getContext();
+  mlir::OpBuilder builder(ctx);
+  mlir::Location loc = builder.getUnknownLoc();
+
+  // Sets up guard.
+  mlir::OpBuilder::InsertionGuard g(builder);
+  builder.setInsertionPointToStart(module.getBody());
+
+  // Sets up vectors for GlobalCtorsOp.
+  llvm::SmallVector<mlir::Attribute> ctors;
+  llvm::SmallVector<int32_t> prios;
+  llvm::SmallVector<mlir::Attribute> datals;
+
+  // Define types for functions.
+  auto voidTy = LLVM::LLVMVoidType::get(ctx);
+  auto funcTy = LLVM::LLVMFunctionType::get(voidTy, {});
+
+  // Makes sure no kInit or "ctor" function had been created.
+  assert(!module.lookupSymbol(kInit) || "unexpected kInit function");
+  assert(!module.lookupSymbol("ctor") || "unexpected ctor function");
+
+  // LLVM global ctor requires non-external function. Here, we create a
+  // ctor function as a wrapper to the BRT init external function.
+  auto init = LLVM::LLVMFuncOp::create(builder, loc, kInit, funcTy);
+  auto ctor = LLVM::LLVMFuncOp::create(builder, loc, "ctor", funcTy);
+
+  // Insert call to kInit in ctor.
+  {
+    mlir::OpBuilder::InsertionGuard g(builder);
+    auto entryBlk = ctor.addEntryBlock(builder);
+    builder.setInsertionPointToStart(entryBlk);
+    LLVM::CallOp::create(builder, loc, init, ValueRange{});
+    LLVM::ReturnOp::create(builder, loc, ValueRange{});
+  }
+
+  // Take note of the newly created ctor function.
+  ctors.push_back(FlatSymbolRefAttr::get(ctx, "ctor"));
+  prios.push_back(0);
+  datals.push_back(LLVM::ZeroAttr::get(ctx));
+
+  // We assume that there is no existing GlobalCtorsOp.
+  LLVM::GlobalCtorsOp::create(
+      builder, loc, builder.getArrayAttr(ctors),
+      builder.getI32ArrayAttr(prios), builder.getArrayAttr(datals));
+}
+
 } // namespace
 
 void belalang::bir::populateBelalangBIRToLLVMPatterns(
@@ -648,6 +698,8 @@ struct BelalangBIRToLLVMPass
       BelalangBIRToLLVMPass>::BelalangBIRToLLVMPassBase;
 
   void runOnOperation() override {
+    insertBRTInitCall(getOperation());
+
     BIRToLLVMTypeConverter typeConverter(&getContext());
 
     mlir::ConversionTarget target(getContext());

--- a/bir/lib/Transforms/LowerToRuntimeCalls.cpp
+++ b/bir/lib/Transforms/LowerToRuntimeCalls.cpp
@@ -102,44 +102,6 @@ struct PrintOpLowering : public mlir::OpRewritePattern<PrintOp> {
   }
 };
 
-static bool hasBRTInitCall(bir::FuncOp mainFunc) {
-  bool found = false;
-  mainFunc.walk([&found](bir::CallOp callOp) {
-    if (callOp.getCallee() == llvm::StringRef(kInit)) {
-      found = true;
-      return mlir::WalkResult::interrupt();
-    }
-    return mlir::WalkResult::advance();
-  });
-  return found;
-}
-
-static void insertBRTInitCall(mlir::Operation *op) {
-  mlir::ModuleOp module = dyn_cast_or_null<mlir::ModuleOp>(op);
-  assert(module);
-
-  mlir::OpBuilder builder(module.getContext());
-
-  auto mainFunc = module.lookupSymbol<bir::FuncOp>("main");
-  if (!mainFunc || mainFunc.isExternal())
-    return;
-
-  if (!module.lookupSymbol(kInit)) {
-    mlir::OpBuilder::InsertionGuard g(builder);
-    builder.setInsertionPointToStart(module.getBody());
-    auto funcType = mlir::FunctionType::get(builder.getContext(), {}, {});
-    bir::FuncOp::create(builder, builder.getUnknownLoc(), kInit,
-                        funcType);
-  }
-
-  if (!hasBRTInitCall(mainFunc)) {
-    mlir::OpBuilder::InsertionGuard g(builder);
-    builder.setInsertionPointToStart(&mainFunc.getBody().front());
-    auto callee = FlatSymbolRefAttr::get(builder.getContext(), kInit);
-    bir::CallOp::create(builder, builder.getUnknownLoc(), callee, {}, {});
-  }
-}
-
 } // namespace
 
 void belalang::bir::populateBelalangLowerToRuntimeCallsPatterns(
@@ -157,8 +119,6 @@ struct BelalangLowerToRuntimeCallsPass
       BelalangLowerToRuntimeCallsPass>::BelalangLowerToRuntimeCallsPassBase;
 
   void runOnOperation() override {
-    insertBRTInitCall(getOperation());
-
     mlir::RewritePatternSet patterns(&getContext());
     populateBelalangLowerToRuntimeCallsPatterns(patterns);
 

--- a/tests/BIR/Target/LLVMIR/string.mlir
+++ b/tests/BIR/Target/LLVMIR/string.mlir
@@ -2,14 +2,12 @@
 // RUN: | %bir-translate --split-input-file --bir-to-llvmir \
 // RUN: | %FileCheck %s
 
-// CHECK: @str.[[H:.*]] = private constant [5 x i8] c"hello"
+// CHECK-DAG: @str.[[H:.*]] = private constant [5 x i8] c"hello"
+// CHECK-DAG: declare ptr @brt_gc_alloc(i64)
+// CHECK-DAG: declare void @brt_init()
+// CHECK-DAG: @llvm.global_ctors {{.*}} ptr @ctor
 
-// CHECK: declare ptr @brt_gc_alloc(i64)
-
-// CHECK: declare void @brt_init()
-
-// CHECK:      define { ptr, i64 } @main() {
-// CHECK-NEXT:   call void @brt_init()
+// CHECK-LABEL:define { ptr, i64 } @main() {
 // CHECK-NEXT:   %[[C1:.*]] = call ptr @brt_gc_alloc(i64 16)
 // CHECK-NEXT:   store { ptr, i64 } { ptr @str.[[H]], i64 5 }, ptr %[[C1]], align 8
 // CHECK-NEXT:   %[[C2:.*]] = load { ptr, i64 }, ptr %[[C1]], align 8
@@ -29,16 +27,13 @@ bir.func @main() -> !bir.string {
 
 // -----
 
-// CHECK: @str.[[H:.*]] = private constant [5 x i8] c"hello"
+// CHECK-DAG: @str.[[H:.*]] = private constant [5 x i8] c"hello"
+// CHECK-DAG: declare ptr @brt_gc_alloc(i64)
+// CHECK-DAG: declare void @brt_print_string({ ptr, i64 })
+// CHECK-DAG: declare void @brt_init()
+// CHECK-DAG: @llvm.global_ctors {{.*}} ptr @ctor
 
-// CHECK: declare ptr @brt_gc_alloc(i64)
-
-// CHECK: declare void @brt_print_string({ ptr, i64 })
-
-// CHECK: declare void @brt_init()
-
-// CHECK:      define void @main() {
-// CHECK-NEXT:   call void @brt_init()
+// CHECK-LABEL:define void @main() {
 // CHECK-NEXT:   %[[C1:.*]] = call ptr @brt_gc_alloc(i64 16)
 // CHECK-NEXT:   store { ptr, i64 } { ptr @str.[[H]], i64 5 }, ptr %[[C1]], align 8
 // CHECK-NEXT:   %[[C2:.*]] = load { ptr, i64 }, ptr %[[C1]], align 8

--- a/tests/BIR/Transforms/BIRToLLVM/arith.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/arith.mlir
@@ -1,7 +1,7 @@
 // RUN: %bir-opt --split-input-file --convert-bir-to-llvm %s | %FileCheck %s
 
 // CHECK: module {
-// CHECK-NEXT: llvm.func @basic() -> i64 {
+// CHECK-LABEL: llvm.func @basic() -> i64 {
 
 bir.func @basic() -> !bir.int {
   // CHECK-NEXT: %0 = llvm.mlir.constant(4 : i64) : i64

--- a/tests/BIR/Transforms/BIRToLLVM/cf.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/cf.mlir
@@ -1,9 +1,6 @@
 // RUN: %bir-opt --split-input-file --bir-lowering-pipeline --convert-bir-to-llvm %s | %FileCheck %s
 
-// CHECK:      module {
-// CHECK-NEXT:   llvm.func @brt_init()
-// CHECK-NEXT:   llvm.func @main() -> i64 {
-// CHECK-NEXT:     llvm.call @brt_init() : () -> ()
+// CHECK-LABEL:  llvm.func @main() -> i64 {
 // CHECK-NEXT:     llvm.br ^bb1
 // CHECK-NEXT:   ^bb1:  // pred: ^bb0
 // CHECK-NEXT:     %[[VAL:.*]] = llvm.mlir.constant(42 : i64) : i64
@@ -11,7 +8,6 @@
 // CHECK-NEXT:   ^bb2(%[[ARG:.*]]: i64):  // pred: ^bb1
 // CHECK-NEXT:     llvm.return %[[ARG]] : i64
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
 
 bir.func @main() -> !bir.int {
   %0 = bir.scope {
@@ -23,10 +19,7 @@ bir.func @main() -> !bir.int {
 
 // -----
 
-// CHECK:      module {
-// CHECK-NEXT:   llvm.func @brt_init()
-// CHECK-NEXT:   llvm.func @main() {
-// CHECK-NEXT:     llvm.call @brt_init() : () -> ()
+// CHECK-LABEL:  llvm.func @main() {
 // CHECK-NEXT:     llvm.br ^bb1
 // CHECK-NEXT:   ^bb1:  // pred: ^bb0
 // CHECK-NEXT:     %[[VAL:.*]] = llvm.mlir.constant(42 : i64) : i64
@@ -34,7 +27,6 @@ bir.func @main() -> !bir.int {
 // CHECK-NEXT:   ^bb2:  // pred: ^bb1
 // CHECK-NEXT:     llvm.return
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
 
 bir.func @main() {
   bir.scope {

--- a/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
+++ b/tests/BIR/Transforms/BIRToLLVM/llvm.mlir
@@ -1,11 +1,9 @@
 // RUN: %bir-opt --split-input-file --convert-bir-to-llvm %s | %FileCheck %s
 
-// CHECK:      module {
-// CHECK-NEXT:   llvm.func @main() {
+// CHECK-LABEL:  llvm.func @main() {
 // CHECK-NEXT:     %[[C0:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-NEXT:     llvm.return
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
 
 bir.func @main() {
   %0 = bir.constant #bir.int<0> : !bir.int
@@ -14,12 +12,10 @@ bir.func @main() {
 
 // -----
 
-// CHECK:      module {
-// CHECK-NEXT:   llvm.func @main() {
+// CHECK-LABEL:  llvm.func @main() {
 // CHECK-NEXT:     %[[C0:.*]] = llvm.mlir.constant(0.000000e+00 : f64) : f64
 // CHECK-NEXT:     llvm.return
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
 
 bir.func @main() {
   %0 = bir.constant #bir.float<0.00> : !bir.float
@@ -28,12 +24,10 @@ bir.func @main() {
 
 // -----
 
-// CHECK:      module {
-// CHECK-NEXT:   llvm.func @main() {
+// CHECK-LABEL:  llvm.func @main() {
 // CHECK-NEXT:     %[[C0:.*]] = llvm.mlir.constant(1.230000e+00 : f64) : f64
 // CHECK-NEXT:     llvm.return
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
 
 bir.func @main() {
   %0 = bir.constant #bir.float<1.23> : !bir.float

--- a/tests/BIR/Transforms/LowerToRuntimeCalls/basic.mlir
+++ b/tests/BIR/Transforms/LowerToRuntimeCalls/basic.mlir
@@ -1,7 +1,0 @@
-// RUN: %bir-opt --split-input-file --bir-lower-to-runtime-calls %s | %FileCheck %s
-
-// CHECK: bir.func @brt_init()
-// CHECK: bir.call @brt_init() : () -> ()
-bir.func @main() {
-  bir.return
-}

--- a/tests/BIRGen/conditionals.bel
+++ b/tests/BIRGen/conditionals.bel
@@ -1,9 +1,6 @@
 # RUN: %belalang build --emit=bir %s | %FileCheck %s
 
-# CHECK:      module {
-# CHECK-NEXT:   bir.func @brt_init()
-# CHECK-NEXT:   bir.func @main() -> !bir.int {
-# CHECK-NEXT:     bir.call @brt_init() : () -> ()
+# CHECK-LABEL:  bir.func @main() -> !bir.int {
 # CHECK-NEXT:     %[[C1:.*]] = bir.constant #bir.bool<true> : !bir.bool
 # CHECK-NEXT:     bir.cond_br %[[C1]] ^bb1, ^bb2
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0
@@ -24,7 +21,6 @@
 # CHECK-NEXT:     %[[C6:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C6]] : !bir.int
 # CHECK-NEXT:   }
-# CHECK-NEXT: }
 
 if true {
     1;

--- a/tests/BIRGen/functions.bel
+++ b/tests/BIRGen/functions.bel
@@ -1,9 +1,7 @@
 # RUN: %belalang build --emit=bir %s | %FileCheck %s
 
-# CHECK:      module {
-# CHECK-NEXT:   bir.func private @brt_print_int(!bir.int)
-# CHECK-NEXT:   bir.func @brt_init()
-# CHECK-NEXT:   bir.func @fn.main.anon(%[[ARG0:.*]]: !bir.int, %[[ARG1:.*]]: !bir.int) -> !bir.int {
+# CHECK-LABEL:  bir.func @fn.main.anon(
+# CHECK-SAME:       %[[ARG0:.*]]: !bir.int, %[[ARG1:.*]]: !bir.int) -> !bir.int {
 # CHECK-NEXT:     %[[V0:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT:     bir.store %[[ARG0]] to %[[V0]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     %[[V1:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
@@ -13,8 +11,8 @@
 # CHECK-NEXT:     %[[V4:.*]] = bir.add %[[V2]], %[[V3]] : (!bir.int, !bir.int) -> !bir.int
 # CHECK-NEXT:     bir.return %[[V4]] : !bir.int
 # CHECK-NEXT:   }
-# CHECK-NEXT:   bir.func @main() -> !bir.int {
-# CHECK-NEXT:     bir.call @brt_init() : () -> ()
+
+# CHECK-LABEL:  bir.func @main() -> !bir.int {
 # CHECK-NEXT:     %[[C0:.*]] = bir.constant #bir.fn<@fn.main.anon> : (!bir.int, !bir.int) -> !bir.int
 # CHECK-NEXT:     %[[V5:.*]] = bir.alloc_heap 8 : !bir.ref<(!bir.int, !bir.int) -> !bir.int>
 # CHECK-NEXT:     bir.store %[[C0]] to %[[V5]] : (!bir.int, !bir.int) -> !bir.int to !bir.ref<(!bir.int, !bir.int) -> !bir.int>
@@ -29,7 +27,6 @@
 # CHECK-NEXT:     %[[C4:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C4]] : !bir.int
 # CHECK-NEXT:   }
-# CHECK-NEXT: }
 
 add := fn(x: Int, y: Int): Int { return x + y }
 p := add(2, 3)

--- a/tests/BIRGen/infix.bel
+++ b/tests/BIRGen/infix.bel
@@ -1,9 +1,6 @@
 # RUN: %belalang build --emit=bir %s | %FileCheck %s
 
-# CHECK: module {
-# CHECK-NEXT: bir.func @brt_init()
-# CHECK-NEXT: bir.func @main() -> !bir.int {
-# CHECK-NEXT:   bir.call @brt_init() : () -> ()
+# CHECK-LABEL: bir.func @main() -> !bir.int {
 
 # CHECK-NEXT: %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C1:.*]] = bir.constant #bir.int<2> : !bir.int
@@ -19,5 +16,4 @@
 
 # CHECK-NEXT: %8 = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT: bir.return %8 : !bir.int
-# CHECK-NEXT: }
 # CHECK-NEXT: }

--- a/tests/BIRGen/print.bel
+++ b/tests/BIRGen/print.bel
@@ -1,15 +1,9 @@
 # RUN: %belalang build --emit=bir %s | %FileCheck %s
 
-# CHECK: module {
-# CHECK-NEXT: bir.func private @brt_print_int(!bir.int)
-# CHECK-NEXT: bir.func @brt_init()
-# CHECK-NEXT: bir.func @main() -> !bir.int {
-# CHECK-NEXT:   bir.call @brt_init() : () -> ()
+# CHECK-LABEL:bir.func @main() -> !bir.int {
 # CHECK-NEXT:   %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT:   bir.call @brt_print_int(%[[C0]]) : (!bir.int) -> ()
 # CHECK-NEXT:   %[[C1:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:   bir.return %[[C1]] : !bir.int
 # CHECK-NEXT: }
 print(1);
-
-# CHECK-NEXT: }

--- a/tests/BIRGen/string.bel
+++ b/tests/BIRGen/string.bel
@@ -1,15 +1,11 @@
 # RUN: %belalang build --emit=bir %s | %FileCheck %s
 
-# CHECK:      module {
-# CHECK-NEXT:   bir.func @brt_init()
-# CHECK-NEXT:   bir.func @main() -> !bir.int {
-# CHECK-NEXT:     bir.call @brt_init() : () -> ()
+# CHECK-LABEL:  bir.func @main() -> !bir.int {
 # CHECK-NEXT:     %0 = bir.constant #bir.string<"hello"> : !bir.string
 # CHECK-NEXT:     %1 = bir.alloc_heap 16 : !bir.ref<!bir.string>
 # CHECK-NEXT:     bir.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
 # CHECK-NEXT:     %2 = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %2 : !bir.int
 # CHECK-NEXT:   }
-# CHECK-NEXT: }
 
 x := "hello";

--- a/tests/BIRGen/variable_declaration.bel
+++ b/tests/BIRGen/variable_declaration.bel
@@ -3,13 +3,9 @@
 x: Int
 y: String
 
-# CHECK:      module {
-# CHECK-NEXT:   bir.func @brt_init()
-# CHECK-NEXT:   bir.func @main() -> !bir.int {
-# CHECK-NEXT:     bir.call @brt_init() : () -> ()
+# CHECK-LABEL:  bir.func @main() -> !bir.int {
 # CHECK-NEXT:     %[[C0:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT:     %[[C1:.*]] = bir.alloc_heap 16 : !bir.ref<!bir.string>
 # CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C2]] : !bir.int
 # CHECK-NEXT:   }
-# CHECK-NEXT: }

--- a/tests/BIRGen/variables.bel
+++ b/tests/BIRGen/variables.bel
@@ -1,15 +1,10 @@
 # RUN: %belalang build --emit=bir %s | %FileCheck %s
 
-# CHECK: module {
-# CHECK-NEXT: bir.func private @brt_print_int(!bir.int)
-# CHECK-NEXT: bir.func @brt_init()
-# CHECK-NEXT: bir.func @main() -> !bir.int {
-# CHECK-NEXT:   bir.call @brt_init() : () -> ()
+# CHECK-LABEL: bir.func @main() -> !bir.int {
 
 # CHECK-NEXT: %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C1:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT: bir.store %[[C0]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
-
 x := 1;
 
 # CHECK-NEXT: %[[C2:.*]] = bir.constant #bir.float<1.000000e+00> : !bir.float
@@ -40,5 +35,4 @@ x += 5;
 
 # CHECK-NEXT: %[[C14:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT: bir.return %[[C14]] : !bir.int
-# CHECK-NEXT: }
 # CHECK-NEXT: }

--- a/tests/BIRGen/while-loops.bel
+++ b/tests/BIRGen/while-loops.bel
@@ -1,9 +1,6 @@
 # RUN: %belalang build --emit=bir %s | %FileCheck %s
 
-# CHECK:      module {
-# CHECK-NEXT:   bir.func @brt_init()
-# CHECK-NEXT:   bir.func @main() -> !bir.int {
-# CHECK-NEXT:     bir.call @brt_init() : () -> ()
+# CHECK-LABEL:  bir.func @main() -> !bir.int {
 # CHECK-NEXT:     %[[C0:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     %[[X:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
 # CHECK-NEXT:     bir.store %[[C0]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
@@ -27,7 +24,6 @@
 # CHECK-NEXT:     %[[C0_RET:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C0_RET]] : !bir.int
 # CHECK-NEXT:   }
-# CHECK-NEXT: }
 
 x := 0;
 while x < 5 {

--- a/tests/LLVMGen/arith.bel
+++ b/tests/LLVMGen/arith.bel
@@ -1,10 +1,8 @@
 # RUN: %belalang build --emit=llvm %s | %FileCheck %s
 
 # CHECK: declare void @brt_print_int(i64)
-# CHECK: declare void @brt_init()
 
-#      CHECK: define i64 @main() {
-# CHECK-NEXT:  call void @brt_init()
+# CHECK-LABEL:define i64 @main() {
 # CHECK-NEXT:  call void @brt_print_int(i64 4)
 # CHECK-NEXT:  ret i64 0
 # CHECK-NEXT: }

--- a/tests/LLVMGen/functions.bel
+++ b/tests/LLVMGen/functions.bel
@@ -1,10 +1,10 @@
 # RUN: %belalang build --emit=llvm %s | %FileCheck %s
 
-# CHECK: declare ptr @brt_gc_alloc(i64)
-# CHECK: declare void @brt_print_int(i64)
-# CHECK: declare void @brt_init()
+# CHECK-DAG: declare ptr @brt_gc_alloc(i64)
+# CHECK-DAG: declare void @brt_print_int(i64)
 
-# CHECK:      define i64 @fn.main.anon(i64 %[[ARG0:.*]], i64 %[[ARG1:.*]]) {
+# CHECK-LABEL:define i64 @fn.main.anon(
+# CHECK-SAME:     i64 %[[ARG0:.*]], i64 %[[ARG1:.*]]) {
 # CHECK-NEXT:   %[[V0:.*]] = call ptr @brt_gc_alloc(i64 8)
 # CHECK-NEXT:   store i64 %[[ARG0]], ptr %[[V0]], align 4
 # CHECK-NEXT:   %[[V1:.*]] = call ptr @brt_gc_alloc(i64 8)
@@ -15,8 +15,7 @@
 # CHECK-NEXT:   ret i64 %[[V4]]
 # CHECK-NEXT: }
 
-# CHECK:      define i64 @main() {
-# CHECK-NEXT:   call void @brt_init()
+# CHECK-LABEL:define i64 @main() {
 # CHECK-NEXT:   %[[V5:.*]] = call ptr @brt_gc_alloc(i64 8)
 # CHECK-NEXT:   store ptr @fn.main.anon, ptr %[[V5]], align 8
 # CHECK-NEXT:   %[[V6:.*]] = load ptr, ptr %[[V5]], align 8

--- a/tests/LLVMGen/print.bel
+++ b/tests/LLVMGen/print.bel
@@ -1,11 +1,9 @@
 # RUN: %belalang build --emit=llvm %s | %FileCheck %s
 
-# CHECK: declare void @brt_print_int(i64)
-# CHECK: declare void @brt_print_bool(i1)
-# CHECK: declare void @brt_init()
+# CHECK-DAG: declare void @brt_print_int(i64)
+# CHECK-DAG: declare void @brt_print_bool(i1)
 
-#      CHECK: define i64 @main() {
-# CHECK-NEXT:  call void @brt_init()
+# CHECK-LABEL:define i64 @main() {
 # CHECK-NEXT:  call void @brt_print_int(i64 1)
 # CHECK-NEXT:  call void @brt_print_bool(i1 true)
 # CHECK-NEXT:  ret i64 0


### PR DESCRIPTION
This change moves the BRT initialization call to GlobalCtorsOp in LLVM. This makes the BRT initialization happen before the main function. To do this, the insertBRTInitCall was moved from LowerToRuntimeCalls to BIRToLLVM and use LLVM types as opposed to BIR types. I believe it makes more sense to have it here. LowerToRuntimeCalls don't depend on adding a BRT Init call.