### PR TITLE
[bir] Implement self-referencing struct type

### DIFF
--- a/include/belalang/BIR/IR/BIR.h
+++ b/include/belalang/BIR/IR/BIR.h
@@ -23,6 +23,7 @@ using namespace llvm;
 #define GET_ATTRDEF_CLASSES
 #include "belalang/BIR/IR/BIRAttrs.h.inc"
 
+#include "belalang/BIR/IR/BIRTypesDetails.h"
 #define GET_TYPEDEF_CLASSES
 #include "belalang/BIR/IR/BIRTypes.h.inc"
 

--- a/include/belalang/BIR/IR/BIRTypes.td
+++ b/include/belalang/BIR/IR/BIRTypes.td
@@ -25,8 +25,13 @@ def BIR_BoolType : BIR_Type<"Bool", "bool"> {
   let summary = "Boolean type";
 }
 
-def BIR_StructType : BIR_Type<"Struct", "struct"> {
+def BIR_StructType : BIR_Type<"Struct", "struct", [MutableType]> {
   let summary = "Struct type";
+
+  let storageClass = "StructTypeStorage";
+  let genStorageClass = 0;
+
+  let genVerifyDecl = 1;
 
   let parameters = (ins
     ArrayRefParameter<"mlir::Type", "struct members">:$members,

--- a/include/belalang/BIR/IR/BIRTypesDetails.h
+++ b/include/belalang/BIR/IR/BIRTypesDetails.h
@@ -1,0 +1,64 @@
+#ifndef BELALANG_BIR_IR_BIRTYPESDETAILS_H_
+#define BELALANG_BIR_IR_BIRTYPESDETAILS_H_
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/TypeSupport.h"
+
+namespace belalang {
+namespace bir {
+namespace detail {
+
+struct StructTypeStorage : public mlir::TypeStorage {
+public:
+  struct KeyTy {
+    llvm::ArrayRef<mlir::Type> members;
+    mlir::StringAttr name;
+
+    KeyTy(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name)
+        : members(members), name(name) {}
+  };
+
+  StructTypeStorage(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name)
+      : members(members), name(name) {}
+
+  // ---------------------------------------------------------------------------
+  // Type Uniquing Infrastructure
+  // ---------------------------------------------------------------------------
+
+  bool operator==(const KeyTy &key) const { return key.name == name; }
+
+  static llvm::hash_code hashKey(const KeyTy &key) {
+    return llvm::hash_value(key.name);
+  }
+
+  static StructTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
+                                      const KeyTy &key) {
+    llvm::ArrayRef<mlir::Type> members = allocator.copyInto(key.members);
+    return new (allocator.allocate<StructTypeStorage>())
+        StructTypeStorage(members, key.name);
+  }
+
+  mlir::LogicalResult mutate(mlir::TypeStorageAllocator &allocator,
+                             llvm::ArrayRef<mlir::Type> members,
+                             mlir::StringAttr name) {
+    if (this->members == members)
+      return mlir::success();
+
+    // Already defined differently.
+    if (!this->members.empty())
+      return mlir::failure();
+
+    this->members = allocator.copyInto(members);
+    this->name = name;
+    return mlir::success();
+  }
+
+  llvm::ArrayRef<mlir::Type> members;
+  mlir::StringAttr name;
+};
+
+} // namespace detail
+} // namespace bir
+} // namespace belalang
+
+#endif // BELALANG_BIR_IR_BIRTYPESDETAILS_H_

--- a/lib/BIR/IR/BIRTypes.cpp
+++ b/lib/BIR/IR/BIRTypes.cpp
@@ -4,6 +4,9 @@ namespace belalang {
 namespace bir {
 
 mlir::Type StructType::parse(mlir::AsmParser &p) {
+  const mlir::SMLoc loc = p.getCurrentLocation();
+  const mlir::Location eLoc = p.getEncodedSourceLoc(loc);
+
   mlir::MLIRContext *ctx = p.getContext();
   std::string name;
   llvm::SmallVector<mlir::Type> members;
@@ -15,6 +18,32 @@ mlir::Type StructType::parse(mlir::AsmParser &p) {
   // `<structname>`
   if (p.parseString(&name).failed())
     return {};
+
+  // Matches optional `>`.
+  // This parses a struct type without a body used in self-referencing types.
+  SMLoc greaterLoc = p.getCurrentLocation();
+  if (p.parseOptionalGreater().succeeded()) {
+    auto nameAttr = p.getBuilder().getStringAttr(name);
+    auto structTy = StructType::get(ctx, {}, nameAttr);
+
+    // No struct type in the current parse stack.
+    if (succeeded(p.tryStartCyclicParse(structTy))) {
+      p.emitError(greaterLoc,
+                  "struct without a body only allowed in a recursive struct");
+      return {};
+    }
+
+    return structTy;
+  }
+
+  auto nameAttr = mlir::StringAttr::get(ctx, name);
+  auto structTy = StructType::get(ctx, {}, nameAttr);
+
+  auto cyclicParse = p.tryStartCyclicParse(structTy);
+  if (failed(cyclicParse)) {
+    p.emitError(loc, "nested recursive struct definition is not supported");
+    return {};
+  }
 
   // `,`
   if (p.parseComma().failed())
@@ -30,17 +59,40 @@ mlir::Type StructType::parse(mlir::AsmParser &p) {
   if (p.parseGreater().failed())
     return {};
 
-  auto nameAttr = mlir::StringAttr::get(ctx, name);
-  return StructType::get(ctx, members, nameAttr);
+  if (structTy.mutate(members, nameAttr).failed()) {
+    p.emitError(loc, "failed to mutate recursive struct");
+    return {};
+  }
+  return structTy;
 }
 
 void StructType::print(mlir::AsmPrinter &p) const {
+  FailureOr<AsmPrinter::CyclicPrintReset> cyclicPrint;
+
   p << '<';
+  cyclicPrint = p.tryStartCyclicPrint(*this);
   p.printString(getName());
+  if (failed(cyclicPrint)) {
+    p << ">";
+    return;
+  }
   p << ", {";
   llvm::interleaveComma(getMembers(), p);
   p << "}>";
 }
+
+mlir::LogicalResult
+StructType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
+                   llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name) {
+  if (!name)
+    return emitError() << "struct type must have a name";
+  return mlir::success();
+}
+
+llvm::ArrayRef<mlir::Type> StructType::getMembers() const {
+  return getImpl()->members;
+}
+mlir::StringAttr StructType::getName() const { return getImpl()->name; }
 
 } // namespace bir
 } // namespace belalang

--- a/tests/BIR/IR/struct-type.mlir
+++ b/tests/BIR/IR/struct-type.mlir
@@ -13,3 +13,11 @@ bir.func @f(%0: !bir.struct<"T", {!bir.int, !bir.int}>) {
 bir.func @f(%0: !bir.struct<"T", {}>) {
   bir.return
 }
+
+// -----
+
+// CHECK: !struct_T = !bir.struct<"T", {!bir.ref<!bir.struct<"T">>}>
+// CHECK: bir.func @f(%{{.*}}: !struct_T)
+bir.func @f(%0: !bir.struct<"T", {!bir.ref<!bir.struct<"T">>}>) {
+  bir.return
+}


### PR DESCRIPTION
Closes #304 

This change implements BIR struct type referencing itself in its body. The implementation took a lot of inspirations from CIR's StructType and LLVM Dialect's LLVMStructType.