### PR TITLE
[bin] Separate bir and bir-lowered emit targets

### DIFF
--- a/bin/belalang/CmdBuild.cpp
+++ b/bin/belalang/CmdBuild.cpp
@@ -44,6 +44,7 @@ namespace cmd {
 
 enum class EmitTarget {
   Bir,
+  BirLowered,
   Ast,
   Tokens,
   Llvm,
@@ -64,6 +65,8 @@ int build(muopt::Parser &parser) {
         emit = EmitTarget::Ast;
       if (value == "bir")
         emit = EmitTarget::Bir;
+      if (value == "bir-lowered")
+        emit = EmitTarget::BirLowered;
       if (value == "llvm")
         emit = EmitTarget::Llvm;
     }
@@ -128,7 +131,7 @@ int build(muopt::Parser &parser) {
     return parser.hadError() ? 1 : 0;
   }
 
-  if (emit == EmitTarget::Bir) {
+  if (emit == EmitTarget::Bir || emit == EmitTarget::BirLowered) {
     lexer::Lexer lexer(src, diagEngine);
 
     ast::ASTContext astCtx;
@@ -141,7 +144,7 @@ int build(muopt::Parser &parser) {
     birgen::BIRGen birgen(diagEngine);
     birgen.generateProgram(prog);
 
-    if (!birgen.runLoweringPipeline()) {
+    if (emit == EmitTarget::BirLowered && !birgen.runLoweringPipeline()) {
       std::cerr << "error: BIR lowering pipeline failed\n";
       return 1;
     }

--- a/tests/BIRGen/block_yield.bel
+++ b/tests/BIRGen/block_yield.bel
@@ -6,12 +6,11 @@ x: Int = {
     42
 }
 
-# CHECK:      cf.br ^bb1
-# CHECK-NEXT: ^bb1:  // pred: ^bb0
+# CHECK:      %[[VAL:.*]] = bir.scope {
 # CHECK-NEXT:   %[[C1:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT:   %[[C2:.*]] = bir.constant #bir.int<2> : !bir.int
 # CHECK-NEXT:   %[[C3:.*]] = bir.constant #bir.int<42> : !bir.int
-# CHECK-NEXT:   cf.br ^bb2(%[[C3]] : !bir.int)
-# CHECK-NEXT: ^bb2(%[[VAL:.*]]: !bir.int):  // pred: ^bb1
-# CHECK-NEXT:   %[[VAR:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
-# CHECK-NEXT:   bir.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:   bir.yield %[[C3]] : !bir.int
+# CHECK-NEXT: } : !bir.int
+# CHECK-NEXT: %[[VAR:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT: bir.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>

--- a/tests/BIRGen/conditionals.bel
+++ b/tests/BIRGen/conditionals.bel
@@ -2,22 +2,20 @@
 
 # CHECK-LABEL:  bir.func @main() -> !bir.int {
 # CHECK-NEXT:     %[[C1:.*]] = bir.constant #bir.bool<true> : !bir.bool
-# CHECK-NEXT:     bir.cond_br %[[C1]] ^bb1, ^bb2
-# CHECK-NEXT:   ^bb1:  // pred: ^bb0
-# CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT:     cf.br ^bb3
-# CHECK-NEXT:   ^bb2:  // pred: ^bb0
-# CHECK-NEXT:     cf.br ^bb3
-# CHECK-NEXT:   ^bb3:  // 2 preds: ^bb1, ^bb2
+# CHECK-NEXT:     bir.if %[[C1]] {
+# CHECK-NEXT:       %[[C2:.*]] = bir.constant #bir.int<1> : !bir.int
+# CHECK-NEXT:       bir.yield
+# CHECK-NEXT:     } else {
+# CHECK-NEXT:       bir.yield
+# CHECK-NEXT:     }
 # CHECK-NEXT:     %[[C3:.*]] = bir.constant #bir.bool<false> : !bir.bool
-# CHECK-NEXT:     bir.cond_br %[[C3]] ^bb4, ^bb5
-# CHECK-NEXT:   ^bb4:  // pred: ^bb3
-# CHECK-NEXT:     %[[C4:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT:     cf.br ^bb6(%[[C4]] : !bir.int)
-# CHECK-NEXT:   ^bb5:  // pred: ^bb3
-# CHECK-NEXT:     %[[C5:.*]] = bir.constant #bir.int<0> : !bir.int
-# CHECK-NEXT:     cf.br ^bb6(%[[C5]] : !bir.int)
-# CHECK-NEXT:   ^bb6(%[[VAL:.*]]: !bir.int):  // 2 preds: ^bb4, ^bb5
+# CHECK-NEXT:     %[[VAL:.*]] = bir.if %[[C3]] {
+# CHECK-NEXT:       %[[C4:.*]] = bir.constant #bir.int<1> : !bir.int
+# CHECK-NEXT:       bir.yield %[[C4]] : !bir.int
+# CHECK-NEXT:     } else {
+# CHECK-NEXT:       %[[C5:.*]] = bir.constant #bir.int<0> : !bir.int
+# CHECK-NEXT:       bir.yield %[[C5]] : !bir.int
+# CHECK-NEXT:     }
 # CHECK-NEXT:     %[[C6:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C6]] : !bir.int
 # CHECK-NEXT:   }

--- a/tests/BIRGen/functions.bel
+++ b/tests/BIRGen/functions.bel
@@ -1,29 +1,27 @@
 # RUN: %belalang build --emit=bir %s | %FileCheck %s
 
-# CHECK-LABEL:  bir.func @fn.main.anon(
-# CHECK-SAME:       %[[ARG0:.*]]: !bir.int, %[[ARG1:.*]]: !bir.int) -> !bir.int {
-# CHECK-NEXT:     %[[V0:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
-# CHECK-NEXT:     bir.store %[[ARG0]] to %[[V0]] : !bir.int to !bir.ref<!bir.int>
-# CHECK-NEXT:     %[[V1:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
-# CHECK-NEXT:     bir.store %[[ARG1]] to %[[V1]] : !bir.int to !bir.ref<!bir.int>
-# CHECK-NEXT:     %[[V2:.*]] = bir.load %[[V0]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT:     %[[V3:.*]] = bir.load %[[V1]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT:     %[[V4:.*]] = bir.add %[[V2]], %[[V3]] : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     bir.return %[[V4]] : !bir.int
-# CHECK-NEXT:   }
-
 # CHECK-LABEL:  bir.func @main() -> !bir.int {
-# CHECK-NEXT:     %[[C0:.*]] = bir.constant #bir.fn<@fn.main.anon> : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     %[[V5:.*]] = bir.alloc_heap 8 : !bir.ref<(!bir.int, !bir.int) -> !bir.int>
+# CHECK-NEXT:     %[[C0:.*]] = bir.func_expr : (!bir.int, !bir.int) -> !bir.int {
+# CHECK-NEXT:     ^bb0(%[[ARG0:.*]]: !bir.int, %[[ARG1:.*]]: !bir.int):
+# CHECK-NEXT:       %[[V0:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:       bir.store %[[ARG0]] to %[[V0]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:       %[[V1:.*]] = bir.declare "y" : !bir.ref<!bir.int>
+# CHECK-NEXT:       bir.store %[[ARG1]] to %[[V1]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:       %[[V2:.*]] = bir.load %[[V0]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT:       %[[V3:.*]] = bir.load %[[V1]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT:       %[[V4:.*]] = bir.add %[[V2]], %[[V3]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT:       bir.return %[[V4]] : !bir.int
+# CHECK-NEXT:     }
+# CHECK-NEXT:     %[[V5:.*]] = bir.declare "add" : !bir.ref<(!bir.int, !bir.int) -> !bir.int>
 # CHECK-NEXT:     bir.store %[[C0]] to %[[V5]] : (!bir.int, !bir.int) -> !bir.int to !bir.ref<(!bir.int, !bir.int) -> !bir.int>
 # CHECK-NEXT:     %[[V6:.*]] = bir.load %[[V5]] : (!bir.ref<(!bir.int, !bir.int) -> !bir.int>) -> ((!bir.int, !bir.int) -> !bir.int)
 # CHECK-NEXT:     %[[C1:.*]] = bir.constant #bir.int<2> : !bir.int
 # CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<3> : !bir.int
 # CHECK-NEXT:     %[[C3:.*]] = bir.call_indirect %[[V6]](%[[C1]], %[[C2]]) : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     %[[V7:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[V7:.*]] = bir.declare "p" : !bir.ref<!bir.int>
 # CHECK-NEXT:     bir.store %[[C3]] to %[[V7]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT:     %[[V8:.*]] = bir.load %[[V7]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT:     bir.call @brt_print_int(%[[V8]]) : (!bir.int) -> ()
+# CHECK-NEXT:     bir.print %[[V8]] : !bir.int
 # CHECK-NEXT:     %[[C4:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C4]] : !bir.int
 # CHECK-NEXT:   }

--- a/tests/BIRGen/if_yield.bel
+++ b/tests/BIRGen/if_yield.bel
@@ -7,13 +7,12 @@ x: Int = if true {
 }
 
 # CHECK:      %[[C1:.*]] = bir.constant #bir.bool<true> : !bir.bool
-# CHECK-NEXT: bir.cond_br %[[C1]] ^bb1, ^bb2
-# CHECK-NEXT: ^bb1:  // pred: ^bb0
+# CHECK-NEXT: %[[VAL:.*]] = bir.if %[[C1]] {
 # CHECK-NEXT:   %[[C2:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT:   cf.br ^bb3(%[[C2]] : !bir.int)
-# CHECK-NEXT: ^bb2:  // pred: ^bb0
+# CHECK-NEXT:   bir.yield %[[C2]] : !bir.int
+# CHECK-NEXT: } else {
 # CHECK-NEXT:   %[[C3:.*]] = bir.constant #bir.int<0> : !bir.int
-# CHECK-NEXT:   cf.br ^bb3(%[[C3]] : !bir.int)
-# CHECK-NEXT: ^bb3(%[[VAL:.*]]: !bir.int):  // 2 preds: ^bb1, ^bb2
-# CHECK-NEXT:   %[[VAR:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
-# CHECK-NEXT:   bir.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:   bir.yield %[[C3]] : !bir.int
+# CHECK-NEXT: }
+# CHECK-NEXT: %[[VAR:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT: bir.store %[[VAL]] to %[[VAR]] : !bir.int to !bir.ref<!bir.int>

--- a/tests/BIRGen/print.bel
+++ b/tests/BIRGen/print.bel
@@ -2,7 +2,7 @@
 
 # CHECK-LABEL:bir.func @main() -> !bir.int {
 # CHECK-NEXT:   %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT:   bir.call @brt_print_int(%[[C0]]) : (!bir.int) -> ()
+# CHECK-NEXT:   bir.print %[[C0]] : !bir.int
 # CHECK-NEXT:   %[[C1:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:   bir.return %[[C1]] : !bir.int
 # CHECK-NEXT: }

--- a/tests/BIRGen/scopes.bel
+++ b/tests/BIRGen/scopes.bel
@@ -1,13 +1,12 @@
 # RUN: %belalang build --emit=bir %s | %FileCheck %s
 
-# CHECK:        cf.br ^bb1
-# CHECK-NEXT: ^bb1:  // pred: ^bb0
-# CHECK-NEXT:   %0 = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT:   %1 = bir.constant #bir.int<2> : !bir.int
-# CHECK-NEXT:   cf.br ^bb2(%1 : !bir.int)
-# CHECK-NEXT: ^bb2(%2: !bir.int):  // pred: ^bb1
-# CHECK-NEXT:   %3 = bir.constant #bir.int<0> : !bir.int
-# CHECK-NEXT:   bir.return %3 : !bir.int
+# CHECK:      %[[VAL:.*]] = bir.scope {
+# CHECK-NEXT:   %[[C1:.*]] = bir.constant #bir.int<1> : !bir.int
+# CHECK-NEXT:   %[[C2:.*]] = bir.constant #bir.int<2> : !bir.int
+# CHECK-NEXT:   bir.yield %[[C2]] : !bir.int
+# CHECK-NEXT: } : !bir.int
+# CHECK-NEXT: %[[C0:.*]] = bir.constant #bir.int<0> : !bir.int
+# CHECK-NEXT: bir.return %[[C0]] : !bir.int
 
 {
   1

--- a/tests/BIRGen/string.bel
+++ b/tests/BIRGen/string.bel
@@ -2,7 +2,7 @@
 
 # CHECK-LABEL:  bir.func @main() -> !bir.int {
 # CHECK-NEXT:     %0 = bir.constant #bir.string<"hello"> : !bir.string
-# CHECK-NEXT:     %1 = bir.alloc_heap 16 : !bir.ref<!bir.string>
+# CHECK-NEXT:     %1 = bir.declare "x" : !bir.ref<!bir.string>
 # CHECK-NEXT:     bir.store %0 to %1 : !bir.string to !bir.ref<!bir.string>
 # CHECK-NEXT:     %2 = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %2 : !bir.int

--- a/tests/BIRGen/variable_declaration.bel
+++ b/tests/BIRGen/variable_declaration.bel
@@ -4,8 +4,8 @@ x: Int
 y: String
 
 # CHECK-LABEL:  bir.func @main() -> !bir.int {
-# CHECK-NEXT:     %[[C0:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
-# CHECK-NEXT:     %[[C1:.*]] = bir.alloc_heap 16 : !bir.ref<!bir.string>
+# CHECK-NEXT:     %[[C0:.*]] = bir.declare "x" : !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[C1:.*]] = bir.declare "y" : !bir.ref<!bir.string>
 # CHECK-NEXT:     %[[C2:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C2]] : !bir.int
 # CHECK-NEXT:   }

--- a/tests/BIRGen/variables.bel
+++ b/tests/BIRGen/variables.bel
@@ -3,24 +3,24 @@
 # CHECK-LABEL: bir.func @main() -> !bir.int {
 
 # CHECK-NEXT: %[[C0:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT: %[[C1:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
+# CHECK-NEXT: %[[C1:.*]] = bir.declare "x" : !bir.ref<!bir.int>
 # CHECK-NEXT: bir.store %[[C0]] to %[[C1]] : !bir.int to !bir.ref<!bir.int>
 x := 1;
 
 # CHECK-NEXT: %[[C2:.*]] = bir.constant #bir.float<1.000000e+00> : !bir.float
-# CHECK-NEXT: %[[C3:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.float>
+# CHECK-NEXT: %[[C3:.*]] = bir.declare "y" : !bir.ref<!bir.float>
 # CHECK-NEXT: bir.store %[[C2]] to %[[C3]] : !bir.float to !bir.ref<!bir.float>
 y := 1.0;
 
 # CHECK-NEXT: %[[C4:.*]] = bir.load %[[C1]] : (!bir.ref<!bir.int>) -> !bir.int
 # CHECK-NEXT: %[[C5:.*]] = bir.constant #bir.int<1> : !bir.int
 # CHECK-NEXT: %[[C6:.*]] = bir.add %[[C4]], %[[C5]] : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT: %[[C7:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
+# CHECK-NEXT: %[[C7:.*]] = bir.declare "z" : !bir.ref<!bir.int>
 # CHECK-NEXT: bir.store %[[C6]] to %[[C7]] : !bir.int to !bir.ref<!bir.int>
 # CHECK-NEXT: %[[C8:.*]] = bir.load %[[C7]] : (!bir.ref<!bir.int>) -> !bir.int
 z := x + 1;
 
-# CHECK-NEXT: bir.call @brt_print_int(%[[C8]]) : (!bir.int) -> ()
+# CHECK-NEXT: bir.print %[[C8]] : !bir.int
 print(z);
 
 # CHECK-NEXT: %[[C10:.*]] = bir.constant #bir.int<10> : !bir.int

--- a/tests/BIRGen/while-loops.bel
+++ b/tests/BIRGen/while-loops.bel
@@ -2,25 +2,23 @@
 
 # CHECK-LABEL:  bir.func @main() -> !bir.int {
 # CHECK-NEXT:     %[[C0:.*]] = bir.constant #bir.int<0> : !bir.int
-# CHECK-NEXT:     %[[X:.*]] = bir.alloc_heap 8 : !bir.ref<!bir.int>
+# CHECK-NEXT:     %[[X:.*]] = bir.declare "x" : !bir.ref<!bir.int>
 # CHECK-NEXT:     bir.store %[[C0]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
-# CHECK-NEXT:     cf.br ^bb1
-# CHECK-NEXT:   ^bb1:  // 2 preds: ^bb0, ^bb4
-# CHECK-NEXT:     %[[L1:.*]] = bir.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT:     %[[C5:.*]] = bir.constant #bir.int<5> : !bir.int
-# CHECK-NEXT:     %[[COND:.*]] = bir.cmp lt %[[L1]], %[[C5]] : !bir.int
-# CHECK-NEXT:     bir.cond_br %[[COND]] ^bb2, ^bb5
-# CHECK-NEXT:   ^bb2:  // pred: ^bb1
-# CHECK-NEXT:     cf.br ^bb3
-# CHECK-NEXT:   ^bb3:  // pred: ^bb2
-# CHECK-NEXT:     %[[C1:.*]] = bir.constant #bir.int<1> : !bir.int
-# CHECK-NEXT:     %[[L2:.*]] = bir.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
-# CHECK-NEXT:     %[[ADD:.*]] = bir.add %[[L2]], %[[C1]] : (!bir.int, !bir.int) -> !bir.int
-# CHECK-NEXT:     bir.store %[[ADD]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
-# CHECK-NEXT:     cf.br ^bb4
-# CHECK-NEXT:   ^bb4:  // pred: ^bb3
-# CHECK-NEXT:     cf.br ^bb1
-# CHECK-NEXT:   ^bb5:  // pred: ^bb1
+# CHECK-NEXT:     bir.while {
+# CHECK-NEXT:       %[[L1:.*]] = bir.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT:       %[[C5:.*]] = bir.constant #bir.int<5> : !bir.int
+# CHECK-NEXT:       %[[COND:.*]] = bir.cmp lt %[[L1]], %[[C5]] : !bir.int
+# CHECK-NEXT:       bir.condition %[[COND]]
+# CHECK-NEXT:     } do {
+# CHECK-NEXT:       bir.scope {
+# CHECK-NEXT:         %[[C1:.*]] = bir.constant #bir.int<1> : !bir.int
+# CHECK-NEXT:         %[[L2:.*]] = bir.load %[[X]] : (!bir.ref<!bir.int>) -> !bir.int
+# CHECK-NEXT:         %[[ADD:.*]] = bir.add %[[L2]], %[[C1]] : (!bir.int, !bir.int) -> !bir.int
+# CHECK-NEXT:         bir.store %[[ADD]] to %[[X]] : !bir.int to !bir.ref<!bir.int>
+# CHECK-NEXT:         bir.yield
+# CHECK-NEXT:       }
+# CHECK-NEXT:       bir.yield
+# CHECK-NEXT:     }
 # CHECK-NEXT:     %[[C0_RET:.*]] = bir.constant #bir.int<0> : !bir.int
 # CHECK-NEXT:     bir.return %[[C0_RET]] : !bir.int
 # CHECK-NEXT:   }


### PR DESCRIPTION
Closes #319 

Previously the `bir` emit target ran the lowering pipeline. This made the BIRGen tests also run the lowering pipeline. This is not ideal as we weren't purely testing the BIRGen component, but we were also testing the lowering pipeline.

This change separates the `bir` emit target to `bir` and `bir-lowered`. We currently don't use `bir-lowered` in any tests, but its a nice option to have. I didn't go forward with the idea I proposed in #319 with the flag because I think its adds unnecessary new flags, when it can just be a new emit target.